### PR TITLE
Creación de archivo específico para la configuración compartida de base de datos

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,7 +13,7 @@ from flask.ext.cors import CORS
 from flask.ext.script import Manager
 from flask.ext.migrate import Migrate, MigrateCommand
 
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 from app.mod_profiles.resources.lists import *
 from app.mod_profiles.resources.views import *
 from . import config

--- a/app/mod_profiles/models/Gender.py
+++ b/app/mod_profiles/models/Gender.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 
 class Gender(db.Model):
     # Attributes

--- a/app/mod_profiles/models/Measurement.py
+++ b/app/mod_profiles/models/Measurement.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 
 class Measurement(db.Model):
     # Attributes

--- a/app/mod_profiles/models/MeasurementSource.py
+++ b/app/mod_profiles/models/MeasurementSource.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 
 class MeasurementSource(db.Model):
     # Attributes

--- a/app/mod_profiles/models/MeasurementType.py
+++ b/app/mod_profiles/models/MeasurementType.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 
 # Many-to-many relationship tables
 measurement_units_table = db.Table('measurement_units_table',

--- a/app/mod_profiles/models/MeasurementUnit.py
+++ b/app/mod_profiles/models/MeasurementUnit.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 
 class MeasurementUnit(db.Model):
     # Attributes

--- a/app/mod_profiles/models/Profile.py
+++ b/app/mod_profiles/models/Profile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 
 class Profile(db.Model):
     # Attributes

--- a/app/mod_profiles/models/User.py
+++ b/app/mod_profiles/models/User.py
@@ -4,7 +4,7 @@ from passlib.apps import custom_app_context as pwd_context
 from itsdangerous import (TimedJSONWebSignatureSerializer
                           as Serializer, BadSignature, SignatureExpired)
 from app.config import Config
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 
 class User(db.Model):
     # Attributes

--- a/app/mod_profiles/resources/lists/genderList.py
+++ b/app/mod_profiles/resources/lists/genderList.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import Gender
 from app.mod_profiles.resources.fields.genderFields import GenderFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/lists/measurementList.py
+++ b/app/mod_profiles/resources/lists/measurementList.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import Measurement
 from app.mod_profiles.resources.fields.measurementFields import MeasurementFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/lists/measurementSourceList.py
+++ b/app/mod_profiles/resources/lists/measurementSourceList.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import MeasurementSource
 from app.mod_profiles.resources.fields.measurementSourceFields import MeasurementSourceFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/lists/measurementTypeList.py
+++ b/app/mod_profiles/resources/lists/measurementTypeList.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import MeasurementType
 from app.mod_profiles.resources.fields.measurementTypeFields import MeasurementTypeFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/lists/measurementTypeUnitsList.py
+++ b/app/mod_profiles/resources/lists/measurementTypeUnitsList.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import MeasurementType, MeasurementUnit
 from app.mod_profiles.resources.fields.measurementUnitFields import MeasurementUnitFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/lists/measurementUnitList.py
+++ b/app/mod_profiles/resources/lists/measurementUnitList.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import MeasurementUnit
 from app.mod_profiles.resources.fields.measurementUnitFields import MeasurementUnitFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/lists/profileLatestMeasurementList.py
+++ b/app/mod_profiles/resources/lists/profileLatestMeasurementList.py
@@ -2,8 +2,7 @@
 
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_profiles.models import MeasurementType, Profile
 from app.mod_profiles.resources.fields.measurementFields import MeasurementFields
 
 class ProfileLatestMeasurementList(Resource):

--- a/app/mod_profiles/resources/lists/profileList.py
+++ b/app/mod_profiles/resources/lists/profileList.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import Profile
 from app.mod_profiles.resources.fields.profileFields import ProfileFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/lists/profileMeasurementList.py
+++ b/app/mod_profiles/resources/lists/profileMeasurementList.py
@@ -2,7 +2,7 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_profiles.models import *
+from app.mod_profiles.models import Measurement, Profile
 from app.mod_profiles.resources.fields.measurementFields import MeasurementFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/lists/userList.py
+++ b/app/mod_profiles/resources/lists/userList.py
@@ -2,7 +2,7 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 from app.mod_profiles.models import User
 from app.mod_profiles.resources.fields.userFields import UserFields
 

--- a/app/mod_profiles/resources/views/genderView.py
+++ b/app/mod_profiles/resources/views/genderView.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import Gender
 from app.mod_profiles.resources.fields.genderFields import GenderFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/views/measurementSourceView.py
+++ b/app/mod_profiles/resources/views/measurementSourceView.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import MeasurementSource
 from app.mod_profiles.resources.fields.measurementSourceFields import MeasurementSourceFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/views/measurementTypeView.py
+++ b/app/mod_profiles/resources/views/measurementTypeView.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import MeasurementType
 from app.mod_profiles.resources.fields.measurementTypeFields import MeasurementTypeFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/views/measurementUnitView.py
+++ b/app/mod_profiles/resources/views/measurementUnitView.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import MeasurementUnit
 from app.mod_profiles.resources.fields.measurementUnitFields import MeasurementUnitFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/views/measurementView.py
+++ b/app/mod_profiles/resources/views/measurementView.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import Measurement
 from app.mod_profiles.resources.fields.measurementFields import MeasurementFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/views/profileView.py
+++ b/app/mod_profiles/resources/views/profileView.py
@@ -2,8 +2,8 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
-from app.mod_profiles.models import *
+from app.mod_shared.models.db import db
+from app.mod_profiles.models import Profile
 from app.mod_profiles.resources.fields.profileFields import ProfileFields
 
 parser = reqparse.RequestParser()

--- a/app/mod_profiles/resources/views/userView.py
+++ b/app/mod_profiles/resources/views/userView.py
@@ -2,7 +2,7 @@
 
 from flask_restful import Resource, reqparse, marshal_with
 from flask_restful_swagger import swagger
-from app.mod_shared.models import db
+from app.mod_shared.models.db import db
 from app.mod_profiles.models import User
 from app.mod_profiles.resources.fields.userFields import UserFields
 

--- a/app/mod_shared/models/__init__.py
+++ b/app/mod_shared/models/__init__.py
@@ -1,5 +1,1 @@
 # -*- coding: utf-8 -*-
-
-from flask.ext.sqlalchemy import SQLAlchemy
-
-db = SQLAlchemy()

--- a/app/mod_shared/models/db.py
+++ b/app/mod_shared/models/db.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+from flask.ext.sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()


### PR DESCRIPTION
Se creó un nuevo archivo en el módulo ```mod_shared```, que contiene el **objeto de base de datos** a utilizar en forma global.

Además, se especificaron los ```import *``` de modelos existentes, indicando sólo los modelos necesarios.