### PR TITLE
Especificación del detalle de todos los errores del parser en cada petición

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,9 @@ class Config(object):
     CSRF_ENABLED = True
     SECRET_KEY = 'this-really-needs-to-be-changed'
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'postgresql:///salud_dev?client_encoding=utf8')
+    # Parámetro que indica si el parser de argumentos debe devolver la totalidad de los errores encontrados en una
+    # petición a la API (True), o sólo el primer error (False).
+    BUNDLE_ERRORS = True
 
 
 class ProductionConfig(Config):


### PR DESCRIPTION
Por defecto, el *parser* de **Flask-Restful** sólo devuelve el **primer error** que encuentra en los argumentos de una petición **[1]**. Este cambio configura, **en forma global**, que se especifiquen los errores encontrados en **todos** los argumentos de cada petición.

**[1]** https://flask-restful.readthedocs.org/en/latest/reqparse.html#error-handling