### PR TITLE
Eliminación de atributo 'gender' obsoleto en clase 'Profile'

### DIFF
--- a/app/mod_profiles/models/Profile.py
+++ b/app/mod_profiles/models/Profile.py
@@ -7,7 +7,6 @@ class Profile(db.Model):
     id         = db.Column(db.Integer, primary_key=True)
     last_name  = db.Column(db.String(50))
     first_name = db.Column(db.String(50))
-    gender     = db.Column(db.Integer)
     birthday   = db.Column(db.Date)
     # Foreign keys
     gender_id = db.Column(db.Integer, db.ForeignKey('gender.id'))


### PR DESCRIPTION
Se removió de la clase **Profile** el atributo ```gender``` de tipo ```Integer```, que fue reemplazado por una relación con la clase **Gender**.