### PR TITLE
Corrección en el parseo de argumentos 'date' y 'datetime'

### DIFF
--- a/app/mod_profiles/validators/globalValidator.py
+++ b/app/mod_profiles/validators/globalValidator.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from re import match, split
-from calendar import monthrange
-from datetime import date, time, datetime
+from datetime import date
+from dateutil.parser import parse
 
 
 def is_int(var):
@@ -21,7 +20,7 @@ def is_int(var):
     """
     try:
         return int(var)
-    except ValueError: 
+    except ValueError:
         raise ValueError("El valor ingresado no es un entero válido")
 
 
@@ -81,30 +80,9 @@ def string_without_int(var):
         return var
 
 
-def is_valid_date_format(var):
-    """ Valida que el formato de la fecha sea válido
-    >>> is_valid_date_format('1990-06-20')
-    '1990-06-20'
-
-    >>> is_valid_date_format('20-06-1990')
-    Traceback (most recent call last):
-        ...
-    ValueError: Formato de fecha no válido
-
-    >>> is_valid_date_format('1998-09-a0')
-    Traceback (most recent call last):
-        ...
-    ValueError: Formato de fecha no válido
-
-    >>> is_valid_date_format('1998-09-123')
-    Traceback (most recent call last):
-        ...
-    ValueError: Formato de fecha no válido
-    """
-    if not match(r'(\d{4})[-](\d{1,2})[-](\d{1,2})$', var):
-        raise ValueError("Formato de fecha no válido")
-    else:
-        return var
+def is_valid_id(var):
+    int_var = positive_int(var)
+    return int_var
 
 
 def is_valid_date(var):
@@ -116,28 +94,20 @@ def is_valid_date(var):
     >>> is_valid_date('1990-09-00')
     Traceback (most recent call last):
         ...
-    ValueError: La fecha presenta un error en el día
+    ValueError: day is out of range for month
 
     >>> is_valid_date('1990-00-10')
     Traceback (most recent call last):
         ...
-    ValueError: La fecha presenta un error en el mes
+    ValueError: month must be in 1..12
 
     >>> is_valid_date('0000-09-10')
     Traceback (most recent call last):
         ...
-    ValueError: La fecha presenta un error en el año
+    ValueError: month must be in 1..12
     """
-    is_valid_date_format(var)
-    list_var = split(r'-', var)
-    if not (int(list_var[0]) in range(1, date.max.year)):
-        raise ValueError("La fecha presenta un error en el año")
-    elif not (int(list_var[1]) in range(1, 13)):
-        raise ValueError("La fecha presenta un error en el mes")
-    elif not (int(list_var[2]) in range(1, monthrange(int(list_var[0]), int(list_var[1]))[1] + 1)):
-        raise ValueError("La fecha presenta un error en el día")
-    else:
-        return date(int(list_var[0]), int(list_var[1]), int(list_var[2]))
+    date_var = parse(var).date()
+    return date_var
 
 
 def is_valid_previous_date(var):
@@ -145,60 +115,23 @@ def is_valid_previous_date(var):
     >>> is_valid_previous_date('1990-06-20')
     datetime.date(1990, 6, 20)
 
-    >>> is_valid_previous_date('1914-06-20')
+    >>> is_valid_previous_date('1899-06-20')
     Traceback (most recent call last):
         ...
-    ValueError: No es una fecha previa correcta
+    ValueError: La fecha ingresada no puede ser anterior al año 1900.
 
-    >>> is_valid_previous_date('2016-09-10')
+    >>> is_valid_previous_date('3016-09-10')
     Traceback (most recent call last):
         ...
-    ValueError: No es una fecha previa correcta
-
+    ValueError: La fecha ingresada debe ser anterior a la fecha actual.
     """
     date_var = is_valid_date(var)
-    min_date = date(1915, 1, 1)
-    if not (min_date < date_var < date.today()):
-        raise ValueError("No es una fecha previa correcta")
+    if date_var.year < 1900:
+        raise ValueError("La fecha ingresada no puede ser anterior al año 1900.")
+    elif date_var > date.today():
+        raise ValueError("La fecha ingresada no debe ser posterior a la fecha actual.")
     else:
         return date_var
-
-
-def is_valid_id(var):
-    int_var = positive_int(var)
-    return int_var
-
-
-def is_valid_time_format(var):
-    """ Valida que el formato de tiempo sea correcto
-    >>> is_valid_time_format('13:32:22.386348')
-    [13, 32, 22, 386348]
-
-    >>> is_valid_time_format('113:32:22.386348')
-    Traceback (most recent call last):
-        ...
-    ValueError: El formato del tiempo no es válido
-    """
-    var = match(r'\d{1,2}:\d{1,2}:\d{1,2}.\d{1,6}$', var)
-    if not var:
-        raise ValueError("El formato del tiempo no es válido")
-    else:
-        list_var = split(r'[:|.]', var.group())
-        return [int(i) for i in list_var]
-
-
-def is_valid_time(var):
-    list_var = is_valid_time_format(var)
-    if not 0 <= list_var[0] < 24:
-        raise ValueError("Error en la hora de la fecha")
-    elif not 0 <= list_var[1] < 60:
-        raise ValueError("Error en los minutos de la fecha")
-    elif not 0 <= list_var[2] < 60:
-        raise ValueError("Error en los segundos de la fecha")
-    elif not (0 <= list_var[3] < 1000000):
-        raise ValueError("Error en los microsegundos de la fecha")
-    else:
-        return time(list_var[0], list_var[1], list_var[2], list_var[3])
 
 
 def is_valid_datetime(var):
@@ -209,26 +142,17 @@ def is_valid_datetime(var):
     >>> is_valid_datetime("2015-09-12T24:32:22.386348")
     Traceback (most recent call last):
         ...
-    ValueError: Error en la hora de la fecha
+    ValueError: hour must be in 0..23
 
     >>> is_valid_datetime("2015-09-12T13:70:22.386348")
     Traceback (most recent call last):
         ...
-    ValueError: Error en los minutos de la fecha
+    ValueError: minute must be in 0..59
 
     >>> is_valid_datetime("2015-09-12T13:32:60.386348")
     Traceback (most recent call last):
         ...
-    ValueError: Error en los segundos de la fecha
-
-    >>> is_valid_datetime("2015-09-12T13:32:22.1000000")
-    Traceback (most recent call last):
-        ...
-    ValueError: El formato del tiempo no es válido
-
+    ValueError: second must be in 0..59
     """
-    matching = match(r'(^[\d-]{8,10})[^0-9-:.]([\d:.]*$)', var)
-    date_var = is_valid_date(matching.group(1))
-    time_var = is_valid_time(matching.group(2))
-    return datetime(date_var.year, date_var.month, date_var.day, time_var.hour, time_var.minute, time_var.second,
-                    time_var.microsecond)
+    datetime = parse(var)
+    return datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Mako==1.0.1
 MarkupSafe==0.23
 passlib==1.6.5
 psycopg2==2.6
+python-dateutil==2.4.2
 pytz==2015.4
 six==1.9.0
 SQLAlchemy==1.0.4


### PR DESCRIPTION
Se simplificó el parseo de argumentos *date* y *datetime*, haciendo uso del paquete ```python-dateutil```. Específicamente, de su función de parseo ```parser.parse()``` **[1]**.

Además, se solucionaron los errores de validación relacionados a argumentos *datetime* que contenían un valor de zona horaria, o que no presentaban información acerca de microsegundos.

**[1]** https://labix.org/python-dateutil#head-c0e81a473b647dfa787dc11e8c69557ec2c3ecd2