### PR TITLE
Corrección en la comparación de fechas con y sin zona horaria

### DIFF
--- a/app/mod_profiles/resources/views/measurementView.py
+++ b/app/mod_profiles/resources/views/measurementView.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pytz
+from pytz import UTC
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
 from app.mod_shared.models.db import db
@@ -123,15 +123,15 @@ class MeasurementView(Resource):
             # horaria UTC.
             if (current_datetime.tzinfo is None
                   or current_datetime.tzinfo.utcoffset(current_datetime) is None):
-                current_datetime = measurement.datetime.replace(tzinfo=pytz.UTC)
+                current_datetime = measurement.datetime.replace(tzinfo=UTC)
             # Comprueba si el valor nuevo de fecha y hora no tiene información
             # acerca de la zona horaria. Si es así, la configura con zona
             # horaria UTC. Sino, convierte la existente a UTC.
             if (new_datetime.tzinfo is None
                   or new_datetime.tzinfo.utcoffset(new_datetime) is None):
-                new_datetime = new_datetime.replace(tzinfo=pytz.UTC)
+                new_datetime = new_datetime.replace(tzinfo=UTC)
             else:
-                new_datetime = new_datetime.astimezone(pytz.UTC)
+                new_datetime = new_datetime.astimezone(UTC)
             # Luego de hacer comparables los valores (al agregar la información
             # de zona horaria), se actualiza la fecha y hora en caso de que el
             # nuevo valor sea distinto al actual. Se quita la información de

--- a/app/mod_profiles/resources/views/measurementView.py
+++ b/app/mod_profiles/resources/views/measurementView.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import pytz
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
 from app.mod_shared.models.db import db
@@ -113,9 +114,30 @@ class MeasurementView(Resource):
         # argumentos recibidos.
 
         # Actualiza la fecha y hora, en caso de que haya sido modificada.
-        if (args['datetime'] is not None and
-              measurement.datetime != args['datetime']):
-            measurement.datetime = args['datetime']
+        if args['datetime'] is not None:
+            # Obtiene los valores de fecha y hora, actual y nuevo.
+            current_datetime = measurement.datetime
+            new_datetime = args['datetime']
+            # Comprueba si el valor actual de fecha y hora no tiene información
+            # acerca de la zona horaria. Si es así, la configura con zona
+            # horaria UTC.
+            if (current_datetime.tzinfo is None
+                  or current_datetime.tzinfo.utcoffset(current_datetime) is None):
+                current_datetime = measurement.datetime.replace(tzinfo=pytz.UTC)
+            # Comprueba si el valor nuevo de fecha y hora no tiene información
+            # acerca de la zona horaria. Si es así, la configura con zona
+            # horaria UTC. Sino, convierte la existente a UTC.
+            if (new_datetime.tzinfo is None
+                  or new_datetime.tzinfo.utcoffset(new_datetime) is None):
+                new_datetime = new_datetime.replace(tzinfo=pytz.UTC)
+            else:
+                new_datetime = new_datetime.astimezone(pytz.UTC)
+            # Luego de hacer comparables los valores (al agregar la información
+            # de zona horaria), se actualiza la fecha y hora en caso de que el
+            # nuevo valor sea distinto al actual. Se quita la información de
+            # zona horaria, para su almacenamiento como UTC.
+            if current_datetime != new_datetime:
+                measurement.datetime = new_datetime.replace(tzinfo=None)
         # Actualiza el valor, en caso de que haya sido modificado.
         if (args['value'] is not None and
               measurement.value != args['value']):

--- a/app/mod_profiles/resources/views/measurementView.py
+++ b/app/mod_profiles/resources/views/measurementView.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from pytz import UTC
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
 from app.mod_shared.models.db import db
@@ -114,30 +113,9 @@ class MeasurementView(Resource):
         # argumentos recibidos.
 
         # Actualiza la fecha y hora, en caso de que haya sido modificada.
-        if args['datetime'] is not None:
-            # Obtiene los valores de fecha y hora, actual y nuevo.
-            current_datetime = measurement.datetime
-            new_datetime = args['datetime']
-            # Comprueba si el valor actual de fecha y hora no tiene información
-            # acerca de la zona horaria. Si es así, la configura con zona
-            # horaria UTC.
-            if (current_datetime.tzinfo is None
-                  or current_datetime.tzinfo.utcoffset(current_datetime) is None):
-                current_datetime = measurement.datetime.replace(tzinfo=UTC)
-            # Comprueba si el valor nuevo de fecha y hora no tiene información
-            # acerca de la zona horaria. Si es así, la configura con zona
-            # horaria UTC. Sino, convierte la existente a UTC.
-            if (new_datetime.tzinfo is None
-                  or new_datetime.tzinfo.utcoffset(new_datetime) is None):
-                new_datetime = new_datetime.replace(tzinfo=UTC)
-            else:
-                new_datetime = new_datetime.astimezone(UTC)
-            # Luego de hacer comparables los valores (al agregar la información
-            # de zona horaria), se actualiza la fecha y hora en caso de que el
-            # nuevo valor sea distinto al actual. Se quita la información de
-            # zona horaria, para su almacenamiento como UTC.
-            if current_datetime != new_datetime:
-                measurement.datetime = new_datetime.replace(tzinfo=None)
+        if (args['datetime'] is not None and
+              measurement.datetime != args['datetime']):
+            measurement.datetime = args['datetime']
         # Actualiza el valor, en caso de que haya sido modificado.
         if (args['value'] is not None and
               measurement.value != args['value']):

--- a/app/mod_profiles/validators/globalValidator.py
+++ b/app/mod_profiles/validators/globalValidator.py
@@ -2,6 +2,7 @@
 
 from datetime import date
 from dateutil.parser import parse
+from pytz import UTC
 
 
 def is_int(var):
@@ -155,4 +156,14 @@ def is_valid_datetime(var):
     ValueError: second must be in 0..59
     """
     datetime = parse(var)
+
+    # Comprueba si el valor de fecha y hora tiene información acerca de la zona
+    # horaria. Si es así, convierte la existente a UTC.
+    if (datetime.tzinfo is not None
+          and datetime.tzinfo.utcoffset(datetime) is not None):
+        datetime = datetime.astimezone(UTC)
+
+    # Se quita la información de zona horaria, para su almacenamiento como UTC.
+    datetime = datetime.replace(tzinfo=None)
+
     return datetime


### PR DESCRIPTION
Se soluciona el error existente al tratar de **comparar fechas con información de zona horaria y fechas sin esa información**. Además, se convierten todas las zonas horarias a **UTC**, y se almacenan de esa manera en la base de datos.