### PR TITLE
Implementación del validador de fecha y hora previa

### DIFF
--- a/app/mod_profiles/common/parsers/measurement.py
+++ b/app/mod_profiles/common/parsers/measurement.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from flask_restful import reqparse
-from app.mod_profiles.validators.globalValidator import is_valid_id, is_valid_datetime
+from app.mod_profiles.validators.globalValidator import is_valid_id, is_valid_previous_datetime
 
 # Parser general
 parser = reqparse.RequestParser()
-parser.add_argument('datetime', type=is_valid_datetime, required=True)
+parser.add_argument('datetime', type=is_valid_previous_datetime, required=True)
 parser.add_argument('value', type=float, required=True)
 parser.add_argument('profile_id', type=is_valid_id, required=True)
 parser.add_argument('measurement_source_id', type=is_valid_id)

--- a/app/mod_profiles/validators/globalValidator.py
+++ b/app/mod_profiles/validators/globalValidator.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from datetime import date
+from datetime import date, datetime
 from dateutil.parser import parse
 from pytz import UTC
 
@@ -155,15 +155,39 @@ def is_valid_datetime(var):
         ...
     ValueError: second must be in 0..59
     """
-    datetime = parse(var)
+    datetime_var = parse(var)
 
     # Comprueba si el valor de fecha y hora tiene información acerca de la zona
     # horaria. Si es así, convierte la existente a UTC.
-    if (datetime.tzinfo is not None
-          and datetime.tzinfo.utcoffset(datetime) is not None):
-        datetime = datetime.astimezone(UTC)
+    if (datetime_var.tzinfo is not None
+          and datetime_var.tzinfo.utcoffset(datetime_var) is not None):
+        datetime_var = datetime_var.astimezone(UTC)
 
     # Se quita la información de zona horaria, para su almacenamiento como UTC.
-    datetime = datetime.replace(tzinfo=None)
+    datetime_var = datetime_var.replace(tzinfo=None)
 
-    return datetime
+    return datetime_var
+
+
+def is_valid_previous_datetime(var):
+    """ Valida que la fecha y hora sea previa a la actual.
+    >>> is_valid_previous_datetime("2001-09-21T23:33:22.386348")
+    datetime.datetime(2001, 9, 21, 23, 33, 22, 386348)
+
+    >>> is_valid_previous_datetime("1899-09-21T23:33:22.386348")
+    Traceback (most recent call last):
+        ...
+    ValueError: La fecha y hora ingresada no puede ser anterior al año 1900.
+
+    >>> is_valid_previous_datetime("3016-09-21T23:33:22.386348")
+    Traceback (most recent call last):
+        ...
+    ValueError: La fecha y hora ingresada no debe ser posterior a la fecha y hora actual.
+    """
+    datetime_var = is_valid_datetime(var)
+    if datetime_var.year < 1900:
+        raise ValueError("La fecha y hora ingresada no puede ser anterior al año 1900.")
+    elif datetime_var > datetime.utcnow():
+        raise ValueError("La fecha y hora ingresada no debe ser posterior a la fecha y hora actual.")
+    else:
+        return datetime_var


### PR DESCRIPTION
Se implementó el validador ```is_previous_datetime()```, que añade la **comprobación de que la fecha y hora recibida no sea posterior a la actual**.

Además, se hace uso del nuevo validador en el *parser* de **Measurement**.

Closes #49