### PR TITLE
Creación de recurso '/my/profile' con autenticación

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -107,6 +107,7 @@ api.add_resource(Token, '/token')
 api.add_resource(MeasurementTypeUnitsList, '/measurement_types/<int:id>/units')
 api.add_resource(MyLatestMeasurementList, '/my/measurements/latest')
 api.add_resource(MyMeasurementList, '/my/measurements')
+api.add_resource(MyProfileView, '/my/profile')
 api.add_resource(ProfileLatestMeasurementList, '/profiles/<int:profile_id>/measurements/latest')
 api.add_resource(ProfileMeasurementList, '/profiles/<int:profile_id>/measurements')
 

--- a/app/mod_profiles/common/persistence/profile.py
+++ b/app/mod_profiles/common/persistence/profile.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from app.mod_shared.models.db import db
+from app.mod_profiles.models.Profile import Profile
+
+
+def update(profile, first_name=None, last_name=None, birthday=None, gender_id=None):
+    """Actualiza la información de una instancia de perfil, y la retorna.
+
+    Actualiza los atributos y relaciones de una instancia de perfil, en base a
+    los parámetros recibidos. Retorna el perfil actualizado.
+
+    :param profile: Perfil a ser actualizado.
+    :param first_name: Nombre de la persona.
+    :param last_name: Apellido de la persona.
+    :param birthday: Fecha de nacimiento de la persona, en formato ISO 8601.
+    :param gender_id: Identificador único del género asociado al perfil.
+    :return: Perfil actualizado.
+    """
+
+    # Valida que el perfil sea correcto.
+    if not isinstance(profile, Profile):
+        raise ValueError("El perfil especificado es incorrecto.")
+
+    # Actualiza el apellido, en caso de que haya sido modificado.
+    if (last_name is not None and
+          profile.last_name != last_name):
+        profile.last_name = last_name
+    # Actualiza el nombre, en caso de que haya sido modificado.
+    if (first_name is not None and
+          profile.first_name != first_name):
+        profile.first_name = first_name
+    # Actualiza la fecha de nacimiento, en caso de que haya sido
+    # modificada.
+    if (birthday is not None and
+          profile.birthday != birthday):
+        profile.birthday = birthday
+    # Actualiza el genero, en caso de que haya sido modificado.
+    if (gender_id is not None and
+          profile.gender_id != gender_id):
+        profile.gender_id = gender_id
+
+    db.session.commit()
+
+    return profile

--- a/app/mod_profiles/resources/views/__init__.py
+++ b/app/mod_profiles/resources/views/__init__.py
@@ -8,3 +8,5 @@ from .measurementTypeView import MeasurementTypeView
 from .measurementUnitView import MeasurementUnitView
 from .userView import UserView
 from .token import Token
+
+from .myProfileView import MyProfileView

--- a/app/mod_profiles/resources/views/myProfileView.py
+++ b/app/mod_profiles/resources/views/myProfileView.py
@@ -1,28 +1,22 @@
 # -*- coding: utf-8 -*-
 
+from flask import g
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
 
+from app.mod_shared.models.auth import auth
 from app.mod_profiles.common.persistence.profile import update
-from app.mod_profiles.models import Profile
 from app.mod_profiles.common.fields.profileFields import ProfileFields
 from app.mod_profiles.common.parsers.profile import parser_put
 
 
-class ProfileView(Resource):
+class MyProfileView(Resource):
     @swagger.operation(
-        notes=u'Retorna una instancia específica de perfil.'.encode('utf-8'),
+        # TODO: Añadir parámetros de autenticación a la documentación Swagger.
+        notes= (u'Retorna la instancia de perfil asociada al usuario '
+                'autenticado.').encode('utf-8'),
         responseClass='ProfileFields',
         nickname='profileView_get',
-        parameters=[
-            {
-              "name": "id",
-              "description": u'Identificador único del perfil.'.encode('utf-8'),
-              "required": True,
-              "dataType": "int",
-              "paramType": "path"
-            }
-          ],
         responseMessages=[
             {
               "code": 200,
@@ -34,23 +28,19 @@ class ProfileView(Resource):
             }
           ]
         )
+    @auth.login_required
     @marshal_with(ProfileFields.resource_fields, envelope='resource')
-    def get(self, id):
-        profile = Profile.query.get_or_404(id)
+    def get(self):
+        # Obtiene el perfil.
+        profile = g.user.profile
         return profile
 
     @swagger.operation(
-        notes=u'Actualiza una instancia específica de perfil, y la retorna.'.encode('utf-8'),
+        notes=(u'Actualiza la instancia de perfil asociada al usuario '
+               'autenticado, y la retorna.').encode('utf-8'),
         responseClass='ProfileFields',
         nickname='profileView_put',
         parameters=[
-            {
-              "name": "id",
-              "description": u'Identificador único del perfil.'.encode('utf-8'),
-              "required": True,
-              "dataType": "int",
-              "paramType": "path"
-            },
             {
               "name": "last_name",
               "description": u'Apellido de la persona.'.encode('utf-8'),
@@ -91,10 +81,11 @@ class ProfileView(Resource):
             }
           ]
         )
+    @auth.login_required
     @marshal_with(ProfileFields.resource_fields, envelope='resource')
-    def put(self, id):
+    def put(self):
         # Obtiene el perfil.
-        profile = Profile.query.get_or_404(id)
+        profile = g.user.profile
 
         # Obtiene los valores de los argumentos recibidos en la petición.
         args = parser_put.parse_args()


### PR DESCRIPTION
Se creó el recurso ```/my/profile```, que hace uso de la **autenticación para obtener la información del perfil** asociado al usuario. Permite los métodos **GET** y **PUT**.

Además, se implementa la lógica de **actualización de un perfil** en el paquete ```common/persistence```, para ser utilizado por los recursos con y sin autenticación.