### PR TITLE
Creación de recurso '/my/user' con autenticación

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -108,6 +108,7 @@ api.add_resource(MeasurementTypeUnitsList, '/measurement_types/<int:id>/units')
 api.add_resource(MyLatestMeasurementList, '/my/measurements/latest')
 api.add_resource(MyMeasurementList, '/my/measurements')
 api.add_resource(MyProfileView, '/my/profile')
+api.add_resource(MyUserView, '/my/user')
 api.add_resource(ProfileLatestMeasurementList, '/profiles/<int:profile_id>/measurements/latest')
 api.add_resource(ProfileMeasurementList, '/profiles/<int:profile_id>/measurements')
 

--- a/app/mod_profiles/common/persistence/user.py
+++ b/app/mod_profiles/common/persistence/user.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from app.mod_shared.models.db import db
+from app.mod_profiles.models.User import User
+
+
+def update(user, username=None, email=None, password=None, profile_id=None):
+    """Actualiza la información de una instancia de usuario, y la retorna.
+
+    Actualiza los atributos y relaciones de una instancia de usuario, en base a
+    los parámetros recibidos. Retorna el usuario actualizado.
+
+    :param user: Usuario a ser actualizado.
+    :param username: Nombre de usuario.
+    :param email: Dirección de correo electrónico del usuario.
+    :param password: Contraseña del usuario, en texto plano.
+    :param profile_id: Identificador único del perfil asociado al usuario.
+    :return: Usuario actualizado.
+    """
+
+    # Valida que el usuario sea correcto.
+    if not isinstance(user, User):
+        raise ValueError("El usuario especificado es incorrecto.")
+
+    # Actualiza el nombre de usuario, en caso de que haya sido modificado.
+    if (username is not None and
+          user.username != username):
+        user.username = username
+    # Actualiza la dirección de correo electrónico, en caso de que haya
+    # sido modificado.
+    if (email is not None and
+          user.email != email):
+        user.email = email
+    # Actualiza la contraseña, en caso de que haya sido modificado.
+    if (password is not None and
+          not user.verify_password(password)):
+        user.hash_password(password)
+    # Actualiza el perfil asociado, en caso de que haya sido modificado.
+    if (profile_id is not None and
+          user.profile_id != profile_id):
+        user.profile_id = profile_id
+
+    db.session.commit()
+
+    return user

--- a/app/mod_profiles/resources/views/__init__.py
+++ b/app/mod_profiles/resources/views/__init__.py
@@ -10,3 +10,4 @@ from .userView import UserView
 from .token import Token
 
 from .myProfileView import MyProfileView
+from .myUserView import MyUserView

--- a/app/mod_profiles/resources/views/myUserView.py
+++ b/app/mod_profiles/resources/views/myUserView.py
@@ -1,28 +1,21 @@
 # -*- coding: utf-8 -*-
 
+from flask import g
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
 
+from app.mod_shared.models.auth import auth
 from app.mod_profiles.common.persistence.user import update
-from app.mod_profiles.models import User
 from app.mod_profiles.common.fields.userFields import UserFields
 from app.mod_profiles.common.parsers.user import parser_put
 
 
-class UserView(Resource):
+class MyUserView(Resource):
     @swagger.operation(
-        notes=u'Retorna una instancia específica de usuario.'.encode('utf-8'),
+        # TODO: Añadir parámetros de autenticación a la documentación Swagger.
+        notes=u'Retorna la instancia de usuario, del usuario autenticado.'.encode('utf-8'),
         responseClass='UserFields',
-        nickname='userView_get',
-        parameters=[
-            {
-              "name": "id",
-              "description": u'Identificador único del usuario.'.encode('utf-8'),
-              "required": True,
-              "dataType": "int",
-              "paramType": "path"
-            }
-          ],
+        nickname='myUserView_get',
         responseMessages=[
             {
               "code": 200,
@@ -34,23 +27,18 @@ class UserView(Resource):
             }
           ]
         )
+    @auth.login_required
     @marshal_with(UserFields.resource_fields, envelope='resource')
-    def get(self, id):
-        user = User.query.get_or_404(id)
-        return user
+    def get(self):
+        return g.user
 
     @swagger.operation(
-        notes=u'Actualiza una instancia específica de usuario, y la retorna.'.encode('utf-8'),
+        # TODO: Añadir parámetros de autenticación a la documentación Swagger.
+        notes=(u'Actualiza la instancia de usuario, del usuario autenticado, '
+               'y la retorna.').encode('utf-8'),
         responseClass='UserFields',
-        nickname='userView_put',
+        nickname='myUserView_put',
         parameters=[
-            {
-              "name": "id",
-              "description": u'Identificador único del usuario.'.encode('utf-8'),
-              "required": True,
-              "dataType": "int",
-              "paramType": "path"
-            },
             {
               "name": "username",
               "description": u'Nombre de usuario.'.encode('utf-8'),
@@ -91,10 +79,11 @@ class UserView(Resource):
             }
           ]
         )
+    @auth.login_required
     @marshal_with(UserFields.resource_fields, envelope='resource')
-    def put(self, id):
+    def put(self):
         # Obtiene el usuario.
-        user = User.query.get_or_404(id)
+        user = g.user
 
         # Obtiene los valores de los argumentos recibidos en la petición.
         args = parser_put.parse_args()


### PR DESCRIPTION
Se creó el recurso ```/my/user```, que hace uso de la **autenticación para obtener la información del usuario**. Permite los métodos **GET** y **PUT**.

Además, se implementa la lógica de **actualización de un usuario** en el paquete ```common/persistence```, para ser utilizado por los recursos con y sin autenticación.