### PR TITLE
Corrección de parámetros Swagger en recurso 'MeasurementUnitList'

### DIFF
--- a/app/mod_profiles/resources/lists/measurementUnitList.py
+++ b/app/mod_profiles/resources/lists/measurementUnitList.py
@@ -31,13 +31,6 @@ class MeasurementUnitList(Resource):
         nickname='measurementUnitList_post',
         parameters=[
             {
-              "name": "id",
-              "description": u'Identificador único de la unidad de medición.'.encode('utf-8'),
-              "required": True,
-              "dataType": "int",
-              "paramType": "path"
-            },
-            {
               "name": "name",
               "description": u'Nombre de la unidad de medición.'.encode('utf-8'),
               "required": True,


### PR DESCRIPTION
Se **elimina el parámetro ```id```** de la lista de parámetros Swagger del recurso ```MeasurementUnitList```, debido a que se mantuvo incorrectamente al copiarlo desde el recurso ```MeasurementUnitView```.