### PR TITLE
Implementación de recurso POST para creación de medición con usuario autenticado

### DIFF
--- a/app/mod_profiles/common/parsers/measurement.py
+++ b/app/mod_profiles/common/parsers/measurement.py
@@ -20,3 +20,6 @@ parser_post = parser.copy()
 
 # Parser para recurso PUT
 parser_put = parser.copy()
+
+# Parser para recurso POST con usuario autenticado
+parser_post_auth = parser.copy().remove_argument('profile_id')


### PR DESCRIPTION
Se añade el recurso **POST** a ```/my/measurements```, para poder crear una medición asociada al usuario autenticado. No requiere especificar el ```profile_id```, sino que hace uso del perfil del usuario que realiza la petición.