### PR TITLE
Eliminación de parámetros Swagger incorrectos en recursos POST

### DIFF
--- a/app/mod_profiles/resources/lists/measurementList.py
+++ b/app/mod_profiles/resources/lists/measurementList.py
@@ -31,13 +31,6 @@ class MeasurementList(Resource):
         nickname='measurementList_post',
         parameters=[
             {
-              "name": "id",
-              "description": u'Identificador único de la medición.'.encode('utf-8'),
-              "required": True,
-              "dataType": "int",
-              "paramType": "path"
-            },
-            {
               "name": "datetime",
               "description": u'Fecha y hora de la medición.'.encode('utf-8'),
               "required": True,

--- a/app/mod_profiles/resources/lists/profileList.py
+++ b/app/mod_profiles/resources/lists/profileList.py
@@ -31,13 +31,6 @@ class ProfileList(Resource):
         nickname='profileList_post',
         parameters=[
             {
-              "name": "id",
-              "description": u'Identificador único del perfil.'.encode('utf-8'),
-              "required": True,
-              "dataType": "int",
-              "paramType": "path"
-            },
-            {
               "name": "last_name",
               "description": u'Apellido de la persona.'.encode('utf-8'),
               "required": True,


### PR DESCRIPTION
Se eliminan los parámetros de tipo ```path``` existentes en los métodos POST de ```MeasurementList``` y ```ProfileList```, ya que no corresponden. Estos recursos no presentan parámetros de tipo ```path```.