### PR TITLE
Inclusión de respuesta Swagger 401 en recursos con autenticación

### DIFF
--- a/app/mod_profiles/resources/lists/myAnalysisList.py
+++ b/app/mod_profiles/resources/lists/myAnalysisList.py
@@ -8,7 +8,8 @@ from app.mod_shared.models.auth import auth
 from app.mod_shared.models.db import db
 from app.mod_profiles.common.fields.analysisFields import AnalysisFields
 from app.mod_profiles.common.parsers.analysis import parser_post_auth
-from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_201_created, code_404
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_201_created, code_401, \
+    code_404
 from app.mod_profiles.models.Analysis import Analysis
 
 
@@ -21,6 +22,7 @@ class MyAnalysisList(Resource):
         nickname='myAnalysisList_get',
         responseMessages=[
             code_200_found,
+            code_401,
             code_404
         ]
     )
@@ -57,7 +59,8 @@ class MyAnalysisList(Resource):
             }
           ],
         responseMessages=[
-            code_201_created
+            code_201_created,
+            code_401
         ]
     )
     @auth.login_required

--- a/app/mod_profiles/resources/lists/myLatestMeasurementList.py
+++ b/app/mod_profiles/resources/lists/myLatestMeasurementList.py
@@ -7,7 +7,7 @@ from flask_restful_swagger import swagger
 from app.mod_shared.models.auth import auth
 from app.mod_profiles.common.fields.measurementFields import MeasurementFields
 from app.mod_profiles.common.persistence import measurement
-from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_401
 
 
 class MyLatestMeasurementList(Resource):
@@ -23,7 +23,8 @@ class MyLatestMeasurementList(Resource):
         responseClass='MeasurementFields',
         nickname='myLatestMeasurementList_get',
         responseMessages=[
-            code_200_found
+            code_200_found,
+            code_401
         ]
     )
     @auth.login_required

--- a/app/mod_profiles/resources/lists/myMeasurementList.py
+++ b/app/mod_profiles/resources/lists/myMeasurementList.py
@@ -8,7 +8,7 @@ from app.mod_shared.models.auth import auth
 from app.mod_profiles.common.fields.measurementFields import MeasurementFields
 from app.mod_profiles.common.persistence import measurement
 from app.mod_profiles.common.parsers.profileMeasurementList import parser_get
-from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_401
 
 
 class MyMeasurementList(Resource):
@@ -57,7 +57,8 @@ class MyMeasurementList(Resource):
             }
           ],
         responseMessages=[
-            code_200_found
+            code_200_found,
+            code_401
         ]
     )
     @auth.login_required

--- a/app/mod_profiles/resources/views/myProfileView.py
+++ b/app/mod_profiles/resources/views/myProfileView.py
@@ -8,7 +8,8 @@ from app.mod_shared.models.auth import auth
 from app.mod_profiles.common.persistence.profile import update
 from app.mod_profiles.common.fields.profileFields import ProfileFields
 from app.mod_profiles.common.parsers.profile import parser_put
-from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_200_updated, code_404
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_200_updated, code_401, \
+    code_404
 
 
 class MyProfileView(Resource):
@@ -20,6 +21,7 @@ class MyProfileView(Resource):
         nickname='profileView_get',
         responseMessages=[
             code_200_found,
+            code_401,
             code_404
         ]
     )
@@ -67,6 +69,7 @@ class MyProfileView(Resource):
           ],
         responseMessages=[
             code_200_updated,
+            code_401,
             code_404
         ]
     )

--- a/app/mod_profiles/resources/views/myUserView.py
+++ b/app/mod_profiles/resources/views/myUserView.py
@@ -8,7 +8,8 @@ from app.mod_shared.models.auth import auth
 from app.mod_profiles.common.persistence.user import update
 from app.mod_profiles.common.fields.userFields import UserFields
 from app.mod_profiles.common.parsers.user import parser_put
-from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_200_updated, code_404
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_200_updated, code_401, \
+    code_404
 
 
 class MyUserView(Resource):
@@ -19,6 +20,7 @@ class MyUserView(Resource):
         nickname='myUserView_get',
         responseMessages=[
             code_200_found,
+            code_401,
             code_404
         ]
     )
@@ -65,6 +67,7 @@ class MyUserView(Resource):
           ],
         responseMessages=[
             code_200_updated,
+            code_401,
             code_404
         ]
     )


### PR DESCRIPTION
Se incluye la respuesta de **código 401** en la documentación Swagger de los recursos que requieren autenticación.