### PR TITLE
Corrección en el manejo de archivos de Dropbox

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,10 +19,9 @@ class Config(object):
     UPLOADED_PHOTOS_DEST = '/tmp/imagenes'
     MAX_CONT_IMG_LENGTH = 6 * 1024 * 1024
     uploaded_photos = UploadSet('photos', IMAGES)
-    # Para la configuración de la autenticación con dropbox
-    app_key = 'INSERT_APP_KEY'
-    app_secret = 'INSERT_APP_SECRET'
-
+    # Claves, pública y privada, de autenticación de la aplicación en Dropbox.
+    DROPBOX_APP_KEY = 'i7u47ht1t730nar'
+    DROPBOX_APP_SECRET = os.environ.get('DROPBOX_APP_SECRET', '')
 
 
 class ProductionConfig(Config):

--- a/app/mod_profiles/adapters/dropboxAdapter.py
+++ b/app/mod_profiles/adapters/dropboxAdapter.py
@@ -44,4 +44,4 @@ class DropboxAdapter(object):
         except exceptions.HttpError as err:
             print '*** HTTP error', err.message
             return None
-        return res
+        return res.content

--- a/app/mod_profiles/adapters/fileManagerFactory.py
+++ b/app/mod_profiles/adapters/fileManagerFactory.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 from app.mod_profiles.adapters import DropboxAdapter, YesDocAdapter
 
 
@@ -9,7 +11,7 @@ class FileManagerFactory(object):
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
             cls._instance = super(FileManagerFactory, cls).__new__(cls, *args,
-            **kwargs)
+                                                                   **kwargs)
         return cls._instance
 
     def get_file_manager(self, user):
@@ -28,11 +30,18 @@ class FileManagerFactory(object):
         for sc in storage_credentials:
             if sc.token:
                 storage_credential = sc
+                break
 
         if storage_credential is not None:
             file_manager_name = storage_credential.storage_location.name
+            token = storage_credential.token
+        else:
+            file_manager_name = 'Dropbox'
+            token = os.environ.get('DROPBOX_STORAGE_TOKEN', '')
 
-        if file_manager_name is not None and file_manager_name == 'Dropbox':
-            return DropboxAdapter(storage_credential.token)
+        if (file_manager_name is not None
+                and file_manager_name == 'Dropbox'
+                and token is not None):
+            return DropboxAdapter(token)
         else:
             return YesDocAdapter()

--- a/app/mod_profiles/resources/views/analysisFileDownload.py
+++ b/app/mod_profiles/resources/views/analysisFileDownload.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import StringIO
+from StringIO import StringIO
 from flask import g, send_file
 from flask.ext.restful import Resource
 
@@ -19,7 +19,7 @@ class AnalysisFileDownload(Resource):
         user = g.user
         file_manager = FileManagerFactory().get_file_manager(user)
         file_str = file_manager.download_file(file_path)
-        str_in_out = StringIO.StringIO()
+        str_in_out = StringIO()
         str_in_out.write(file_str)
         str_in_out.seek(0)
         return send_file(str_in_out, attachment_filename=file_name, as_attachment=True)


### PR DESCRIPTION
Se corrige la **gestión de las claves de la aplicación en Dropbox**, incluyendo la clave pública e importando la *clave privada** desde la variable de entorno ```DROPBOX_APP_SECRET```.

Además, se corrige la **devolución de archivos cargados en Dropbox**, y se deja este **servicio de almacenamiento como predeterminado**, en caso de que el usuario no cuente con un servicio asociado.