### PR TITLE
Creación de recurso DELETE en AnalysisFileView

### DIFF
--- a/app/mod_profiles/adapters/dropboxAdapter.py
+++ b/app/mod_profiles/adapters/dropboxAdapter.py
@@ -45,3 +45,12 @@ class DropboxAdapter(object):
             print '*** HTTP error', err.message
             return None
         return res.content
+
+    def delete_file(self, path):
+        dbx = dropbox.Dropbox(self.token)
+        try:
+            file_metadata = dbx.files_delete(path)
+        except exceptions.ApiError as err:
+            print '*** API error', err.message
+            return None
+        return file_metadata.name

--- a/app/mod_profiles/common/persistence/analysisFile.py
+++ b/app/mod_profiles/common/persistence/analysisFile.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+from app.mod_profiles.adapters import FileManagerFactory
+from app.mod_profiles.models import AnalysisFile
+
+
+def delete_file(analysis_file):
+    """Elimina el archivo asociado de la ubicación de almacenamiento.
+
+    Elimina el archivo asociado a la instancia especificada, de su ubicación de
+    almacenamiento.
+
+    :param analysis_file: Archivo de análisis, cuyo archivo se debe eliminar.
+    :return: Valor booleano que indica si la eliminación del archivo fue
+    exitosa.
+    """
+
+    # Valida que el archivo de análisis sea correcto.
+    if not isinstance(analysis_file, AnalysisFile):
+        raise ValueError("El archivo de análisis especificado es incorrecto.")
+
+    # Obtiene el usuario asociado al archivo de análisis.
+    user = analysis_file.analysis.profile.user
+
+    # Obtiene la ubicación de almacenamiento asociado al archivo de análisis.
+    file_manager = FileManagerFactory().get_file_manager(user)
+    res = file_manager.delete_file(analysis_file.path)
+
+    if res is None:
+        return False
+    return True

--- a/app/mod_profiles/common/swagger/responses/generic_responses.py
+++ b/app/mod_profiles/common/swagger/responses/generic_responses.py
@@ -36,6 +36,11 @@ code_401 = {
     "message": "Error de autenticación."
 }
 
+code_403 = {
+    "code": 403,
+    "message": "No está autorizado a llevar a cabo la solicitud efectuada."
+}
+
 code_404 = {
     "code": 404,
     "message": "Objeto inexistente."


### PR DESCRIPTION
Se crea el recurso **DELETE** para eliminar un AnalysisFile específico. El recurso requiere que **el usuario autenticado sea el dueño de la instancia de AnalysisFile**.

Además, se implementa el método propio del **adaptador de Dropbox**, para eliminar un archivo.