### PR TITLE
Corrección en recurso de obtención de análisis propios

### DIFF
--- a/app/mod_profiles/resources/lists/myAnalysisList.py
+++ b/app/mod_profiles/resources/lists/myAnalysisList.py
@@ -33,7 +33,7 @@ class MyAnalysisList(Resource):
         profile = g.user.profile
 
         # Obtiene todos los análisis asociados al perfil.
-        analyses = profile.analyses
+        analyses = profile.analyses.all()
         return analyses
 
     @swagger.operation(


### PR DESCRIPTION
Se corrige el funcionamiento del recurso **GET** en ```/my/analyses```, que no retornaba todos los análisis propios, ya que no se obtenían explícitamente los resultados del *query* producto del *backref*.