### PR TITLE
Creación de recursos para obtención de asociaciones del análisis

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -93,13 +93,13 @@ from .mod_shared.models import auth
 # Crea la API y activa el soporte de Swagger para la misma.
 api = swagger.docs(Api(app))
 
-api.add_resource(AnalysisAnalysisFileList, '/analysis/<int:id>/files')
+api.add_resource(AnalysisAnalysisFileList, '/analysis/<int:analysis_id>/files')
 api.add_resource(AnalysisView, '/analysis/<int:id>')
 api.add_resource(AnalysisList, '/analysis')
 api.add_resource(AnalysisFileDownload, '/analysis_files/<int:id>/download')
 api.add_resource(AnalysisFileView, '/analysis_files/<int:id>')
 api.add_resource(AnalysisFileList, '/analysis_files')
-api.add_resource(AnalysisMeasurementList, '/analysis/<int:id>/measurements')
+api.add_resource(AnalysisMeasurementList, '/analysis/<int:analysis_id>/measurements')
 api.add_resource(AnalysisPermissionList, '/analysis/<int:analysis_id>/permissions')
 api.add_resource(GenderView, '/genders/<int:id>')
 api.add_resource(GenderList, '/genders')

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -93,11 +93,13 @@ from .mod_shared.models import auth
 # Crea la API y activa el soporte de Swagger para la misma.
 api = swagger.docs(Api(app))
 
+api.add_resource(AnalysisAnalysisFileList, '/analysis/<int:id>/files')
 api.add_resource(AnalysisView, '/analysis/<int:id>')
 api.add_resource(AnalysisList, '/analysis')
 api.add_resource(AnalysisFileDownload, '/analysis_files/<int:id>/download')
 api.add_resource(AnalysisFileView, '/analysis_files/<int:id>')
 api.add_resource(AnalysisFileList, '/analysis_files')
+api.add_resource(AnalysisMeasurementList, '/analysis/<int:id>/measurements')
 api.add_resource(AnalysisPermissionList, '/analysis/<int:analysis_id>/permissions')
 api.add_resource(GenderView, '/genders/<int:id>')
 api.add_resource(GenderList, '/genders')

--- a/app/mod_profiles/common/parsers/permission.py
+++ b/app/mod_profiles/common/parsers/permission.py
@@ -17,5 +17,5 @@ parser_post.remove_argument('analysis_id')
 
 # Parser para recurso PUT
 parser_put = parser.copy()
-parser_post.remove_argument('analysis_id')
-parser_post.remove_argument('user_id')
+parser_put.remove_argument('analysis_id')
+parser_put.remove_argument('user_id')

--- a/app/mod_profiles/resources/lists/__init__.py
+++ b/app/mod_profiles/resources/lists/__init__.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from .analysisAnalysisFileList import AnalysisAnalysisFileList
 from .analysisFileList import AnalysisFileList
 from .analysisList import AnalysisList
+from .analysisMeasurementList import AnalysisMeasurementList
 from .analysisPermissionList import AnalysisPermissionList
 from .genderList import GenderList
 from .measurementList import MeasurementList

--- a/app/mod_profiles/resources/lists/analysisAnalysisFileList.py
+++ b/app/mod_profiles/resources/lists/analysisAnalysisFileList.py
@@ -44,7 +44,7 @@ class AnalysisAnalysisFileList(Resource):
 
         # Verifica que el usuario autenticado sea el dueño del análisis
         # especificado.
-        if g.user.id != analysis.profile.user.id:
+        if g.user.id != analysis.profile.user.first().id:
             return '', 403
 
         # Obtiene todos los archivos de análisis asociados al análisis.

--- a/app/mod_profiles/resources/lists/analysisAnalysisFileList.py
+++ b/app/mod_profiles/resources/lists/analysisAnalysisFileList.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from flask import g
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
 
+from app.mod_shared.models.auth import auth
 from app.mod_profiles.models import Analysis
 from app.mod_profiles.common.fields.analysisFileFields import AnalysisFileFields
-from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_404
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_ok, code_403, code_404
 
 
 class AnalysisAnalysisFileList(Resource):
@@ -29,14 +31,21 @@ class AnalysisAnalysisFileList(Resource):
             },
         ],
         responseMessages=[
-            code_200_found,
+            code_200_ok,
+            code_403,
             code_404
         ]
     )
+    @auth.login_required
     @marshal_with(resource_fields, envelope='resource')
     def get(self, analysis_id):
         # Obtiene el análisis.
         analysis = Analysis.query.get_or_404(analysis_id)
+
+        # Verifica que el usuario autenticado sea el dueño del análisis
+        # especificado.
+        if g.user.id != analysis.profile.user.id:
+            return '', 403
 
         # Obtiene todos los archivos de análisis asociados al análisis.
         analysis_files = analysis.analysis_files.all()

--- a/app/mod_profiles/resources/lists/analysisAnalysisFileList.py
+++ b/app/mod_profiles/resources/lists/analysisAnalysisFileList.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import Resource, marshal_with
+from flask_restful_swagger import swagger
+
+from app.mod_profiles.models import Analysis
+from app.mod_profiles.common.fields.analysisFileFields import AnalysisFileFields
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_404
+
+
+class AnalysisAnalysisFileList(Resource):
+    # Crea una copia de los campos del modelo 'AnalysisFile'.
+    resource_fields = AnalysisFileFields.resource_fields.copy()
+    # Quita el análisis asociado de los campos del recurso.
+    del resource_fields['analysis']
+
+    @swagger.operation(
+        notes=(u'Retorna todas las instancias existentes de archivos de '
+               'análisis, asociados a un análisis específico.').encode('utf-8'),
+        responseClass='AnalysisFileFields',
+        nickname='analysisAnalysisFileList_get',
+        parameters=[
+            {
+                "name": "analysis_id",
+                "description": u'Identificador único del análisis.'.encode('utf-8'),
+                "required": True,
+                "dataType": "int",
+                "paramType": "path"
+            },
+        ],
+        responseMessages=[
+            code_200_found,
+            code_404
+        ]
+    )
+    @marshal_with(resource_fields, envelope='resource')
+    def get(self, analysis_id):
+        # Obtiene el análisis.
+        analysis = Analysis.query.get_or_404(analysis_id)
+
+        # Obtiene todos los archivos de análisis asociados al análisis.
+        analysis_files = analysis.analysis_files.all()
+        return analysis_files

--- a/app/mod_profiles/resources/lists/analysisMeasurementList.py
+++ b/app/mod_profiles/resources/lists/analysisMeasurementList.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import Resource, marshal_with
+from flask_restful_swagger import swagger
+
+from app.mod_profiles.models import Analysis
+from app.mod_profiles.common.fields.measurementFields import MeasurementFields
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_404
+
+
+class AnalysisMeasurementList(Resource):
+    # Crea una copia de los campos del modelo 'Measurement'.
+    resource_fields = MeasurementFields.resource_fields.copy()
+    # Quita el análisis asociado de los campos del recurso.
+    del resource_fields['analysis']
+
+    @swagger.operation(
+        notes=(u'Retorna todas las instancias existentes de medición, '
+               'asociadas a un análisis específico.').encode('utf-8'),
+        responseClass='MeasurementFields',
+        nickname='analysisMeasurementList_get',
+        parameters=[
+            {
+                "name": "analysis_id",
+                "description": u'Identificador único del análisis.'.encode('utf-8'),
+                "required": True,
+                "dataType": "int",
+                "paramType": "path"
+            },
+        ],
+        responseMessages=[
+            code_200_found,
+            code_404
+        ]
+    )
+    @marshal_with(resource_fields, envelope='resource')
+    def get(self, analysis_id):
+        # Obtiene el análisis.
+        analysis = Analysis.query.get_or_404(analysis_id)
+
+        # Obtiene todas las mediciones asociadas al análisis.
+        measurements = analysis.measurements.all()
+        return measurements

--- a/app/mod_profiles/resources/lists/analysisMeasurementList.py
+++ b/app/mod_profiles/resources/lists/analysisMeasurementList.py
@@ -44,7 +44,7 @@ class AnalysisMeasurementList(Resource):
 
         # Verifica que el usuario autenticado sea el dueño del análisis
         # especificado.
-        if g.user.id != analysis.profile.user.id:
+        if g.user.id != analysis.profile.user.first().id:
             return '', 403
 
         # Obtiene todas las mediciones asociadas al análisis.

--- a/app/mod_profiles/resources/lists/analysisPermissionList.py
+++ b/app/mod_profiles/resources/lists/analysisPermissionList.py
@@ -76,7 +76,7 @@ class AnalysisPermissionList(Resource):
 
         # Verifica que el usuario autenticado sea el dueño del análisis
         # especificado.
-        if g.user.id != analysis.profile.user.id:
+        if g.user.id != analysis.profile.user.first().id:
             return '', 403
 
         # Obtiene los valores de los argumentos recibidos en la petición.

--- a/app/mod_profiles/resources/views/analysisFileView.py
+++ b/app/mod_profiles/resources/views/analysisFileView.py
@@ -144,7 +144,7 @@ class AnalysisFileView(Resource):
         user = g.user
 
         # Verifica que el usuario sea el dueño del archivo de análisis especificado.
-        if user.id != analysis_file.analysis.profile.user.id:
+        if user.id != analysis_file.analysis.profile.user.first().id:
             return '', 403
 
         # Elimina el archivo asociado de la ubicación de almacenamiento.

--- a/app/mod_profiles/resources/views/permissionView.py
+++ b/app/mod_profiles/resources/views/permissionView.py
@@ -76,7 +76,7 @@ class PermissionView(Resource):
 
         # Verifica que el usuario autenticado sea el dueño del análisis
         # asociado al permiso especificado.
-        if g.user.id != permission.analysis.profile.user.id:
+        if g.user.id != permission.analysis.profile.user.first().id:
             return '', 403
 
         # Obtiene los valores de los argumentos recibidos en la petición.
@@ -121,7 +121,7 @@ class PermissionView(Resource):
 
         # Verifica que el usuario autenticado sea el dueño del análisis
         # asociado al permiso especificado.
-        if g.user.id != permission.analysis.profile.user.id:
+        if g.user.id != permission.analysis.profile.user.first().id:
             return '', 403
 
         # Elimina el permiso.


### PR DESCRIPTION
Se crean los recursos **GET** necesarios para obtener las asociaciones de un análisis dado:

* ```/analysis/<analysis_id>/files```: Retorna todas las instancias de ```AnalysisFile``` asociadas al análisis especificado.
* ```/analysis/<analysis_id>/measurements```: Retorna todas las instancias de ```Measurement``` asociadas al análisis especificado.

Además, se corrige el uso de *backref* entre las clases ```Profile``` y ```User```.