### PR TITLE
Creación de recurso DELETE para Analysis

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -94,7 +94,7 @@ from .mod_shared.models import auth
 api = swagger.docs(Api(app))
 
 api.add_resource(AnalysisAnalysisFileList, '/analysis/<int:analysis_id>/files')
-api.add_resource(AnalysisView, '/analysis/<int:id>')
+api.add_resource(AnalysisView, '/analysis/<int:analysis_id>')
 api.add_resource(AnalysisList, '/analysis')
 api.add_resource(AnalysisFileDownload, '/analysis_files/<int:id>/download')
 api.add_resource(AnalysisFileView, '/analysis_files/<int:id>')

--- a/app/mod_profiles/resources/views/analysisFileView.py
+++ b/app/mod_profiles/resources/views/analysisFileView.py
@@ -137,7 +137,7 @@ class AnalysisFileView(Resource):
     @auth.login_required
     @marshal_with(AnalysisFileFields.resource_fields, envelope='resource')
     def delete(self, id):
-        # Obtiene la medición.
+        # Obtiene el archivo de análisis.
         analysis_file = AnalysisFile.query.get_or_404(id)
 
         # Obtiene el usuario autenticado.

--- a/app/mod_profiles/resources/views/analysisView.py
+++ b/app/mod_profiles/resources/views/analysisView.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
 
+from flask import g
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
 
+from app.mod_shared.models.auth import auth
 from app.mod_shared.models.db import db
 from app.mod_profiles.models import Analysis
 from app.mod_profiles.common.fields.analysisFields import AnalysisFields
 from app.mod_profiles.common.parsers.analysis import parser_put
-from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_200_updated, code_404
+from app.mod_profiles.common.persistence import analysisFile
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_200_updated, \
+    code_204_deleted, code_401, code_403, code_404
 
 
 class AnalysisView(Resource):
@@ -30,8 +34,8 @@ class AnalysisView(Resource):
         ]
     )
     @marshal_with(AnalysisFields.resource_fields, envelope='resource')
-    def get(self, id):
-        analysis = Analysis.query.get_or_404(id)
+    def get(self, analysis_id):
+        analysis = Analysis.query.get_or_404(analysis_id)
         return analysis
 
     @swagger.operation(
@@ -74,8 +78,8 @@ class AnalysisView(Resource):
         ]
     )
     @marshal_with(AnalysisFields.resource_fields, envelope='resource')
-    def put(self, id):
-        analysis = Analysis.query.get_or_404(id)
+    def put(self, analysis_id):
+        analysis = Analysis.query.get_or_404(analysis_id)
         args = parser_put.parse_args()
 
         # Actualiza los atributos del objeto, en base a los argumentos
@@ -97,3 +101,54 @@ class AnalysisView(Resource):
 
         db.session.commit()
         return analysis, 200
+
+    @swagger.operation(
+        notes=(u'Elimina una instancia específica de análisis, junto a sus '
+               'mediciones y archivos de análisis asociados.').encode('utf-8'),
+        nickname='analysisView_delete',
+        parameters=[
+            {
+                "name": "id",
+                "description": u'Identificador único del análisis.'.encode('utf-8'),
+                "required": True,
+                "dataType": "int",
+                "paramType": "path"
+            }
+        ],
+        responseMessages=[
+            code_204_deleted,
+            code_401,
+            code_403,
+            code_404
+        ]
+    )
+    @auth.login_required
+    @marshal_with(AnalysisFields.resource_fields, envelope='resource')
+    def delete(self, analysis_id):
+        # Obtiene el análisis.
+        analysis = Analysis.query.get_or_404(analysis_id)
+
+        # Obtiene el usuario autenticado.
+        user = g.user
+
+        # Verifica que el usuario sea el dueño del archivo de análisis especificado.
+        if user.id != analysis.profile.user.first().id:
+            return '', 403
+
+        # Elimina todas las mediciones asociadas al análisis.
+        measurements = analysis.measurements.all()
+        for measurement in measurements:
+            db.session.delete(measurement)
+
+        # Elimina todos los archivos de análisis asociados al análisis.
+        analysis_files = analysis.analysis_files.all()
+        for analysis_file in analysis_files:
+            # Elimina el archivo asociado de la ubicación de almacenamiento.
+            analysisFile.delete_file(analysis_file)
+            db.session.delete(analysis_file)
+
+        # Elimina el análisis.
+        db.session.delete(analysis)
+        db.session.commit()
+
+        return '', 204


### PR DESCRIPTION
Se crea el recurso **DELETE** en ```/analysis/<analysis_id>```. Requiere autenticación por parte del dueño del análisis, y **elimina todas las mediciones y archivos asociados al análisis**, junto con el análisis.