### PR TITLE
Implementación de lógica para permisos

### DIFF
--- a/app/mod_profiles/common/persistence/permission.py
+++ b/app/mod_profiles/common/persistence/permission.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from app.mod_profiles.models import Analysis, User
+
+
+def get_permission_by_user(analysis, user, action):
+    """Indica si el usuario puede efectuar una acción sobre un análisis.
+
+    Retorna el valor booleano que indica si el usuario puede efectuar la acción
+    indicada sobre un análisis específico.
+
+    :param analysis: Instancia de análisis sobre la que se debe ejecutar la
+    acción.
+    :param user: Instancia de usuario que pretende ejecutar la acción.
+    :param action: Acción a ejecutar por el usuario, sobre el análisis. Los
+    valores posibles son 'view_analysis_files', 'edit_analysis_files',
+    'view_measurements' y 'edit_measurements'.
+    :return: Valor booleano que indica si el usuario puede efectuar la acción
+    indicada sobre un análisis específico.
+    """
+
+    # Valida que el análisis sea correcto.
+    if not isinstance(analysis, Analysis):
+        raise ValueError("El análisis especificado es incorrecto.")
+
+    # Valida que el usuario sea correcto.
+    if not isinstance(user, User):
+        raise ValueError("El usuario especificado es incorrecto.")
+
+    # Verifica que el usuario sea el dueño del análisis especificado. Si es
+    # así, retorna verdadero.
+    if user.id == analysis.profile.user.first().id:
+        return True
+
+    # Obtiene el permiso asociado al análisis y al usuario.
+    analysis_permission = analysis.permissions.filter_by(user_id=user.id).first()
+
+    # Verifica si hay algún permiso existente para ese usuario con respecto al
+    # análisis especificado. Si no lo hay, retorna falso.
+    if analysis_permission is None:
+        return False
+
+    permissions = {
+        'view_analysis_files': analysis_permission.can_view_analysis_files,
+        'view_measurements': analysis_permission.can_view_measurements,
+        'edit_analysis_files': analysis_permission.can_edit_analysis_files,
+        'edit_measurements': analysis_permission.can_edit_measurements,
+    }
+
+    return permissions.get(action.lower(), False)

--- a/app/mod_profiles/resources/lists/analysisAnalysisFileList.py
+++ b/app/mod_profiles/resources/lists/analysisAnalysisFileList.py
@@ -7,6 +7,7 @@ from flask_restful_swagger import swagger
 from app.mod_shared.models.auth import auth
 from app.mod_profiles.models import Analysis
 from app.mod_profiles.common.fields.analysisFileFields import AnalysisFileFields
+from app.mod_profiles.common.persistence import permission
 from app.mod_profiles.common.swagger.responses.generic_responses import code_200_ok, code_403, code_404
 
 
@@ -42,9 +43,9 @@ class AnalysisAnalysisFileList(Resource):
         # Obtiene el análisis.
         analysis = Analysis.query.get_or_404(analysis_id)
 
-        # Verifica que el usuario autenticado sea el dueño del análisis
-        # especificado.
-        if g.user.id != analysis.profile.user.first().id:
+        # Verifica que el usuario autenticado tenga permiso para ver los
+        # archivos de análisis, del análisis especificado.
+        if not permission.get_permission_by_user(analysis, g.user, 'view_analysis_files'):
             return '', 403
 
         # Obtiene todos los archivos de análisis asociados al análisis.

--- a/app/mod_profiles/resources/lists/analysisMeasurementList.py
+++ b/app/mod_profiles/resources/lists/analysisMeasurementList.py
@@ -7,6 +7,7 @@ from flask_restful_swagger import swagger
 from app.mod_shared.models.auth import auth
 from app.mod_profiles.models import Analysis
 from app.mod_profiles.common.fields.measurementFields import MeasurementFields
+from app.mod_profiles.common.persistence import permission
 from app.mod_profiles.common.swagger.responses.generic_responses import code_200_ok, code_403, code_404
 
 
@@ -42,9 +43,9 @@ class AnalysisMeasurementList(Resource):
         # Obtiene el análisis.
         analysis = Analysis.query.get_or_404(analysis_id)
 
-        # Verifica que el usuario autenticado sea el dueño del análisis
-        # especificado.
-        if g.user.id != analysis.profile.user.first().id:
+        # Verifica que el usuario autenticado tenga permiso para ver las
+        # mediciones del análisis especificado.
+        if not permission.get_permission_by_user(analysis, g.user, 'view_measurements'):
             return '', 403
 
         # Obtiene todas las mediciones asociadas al análisis.

--- a/app/mod_profiles/resources/lists/measurementList.py
+++ b/app/mod_profiles/resources/lists/measurementList.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
 
+from flask import g
 from flask_restful import Resource, marshal_with
 from flask_restful_swagger import swagger
 
+from app.mod_shared.models.auth import auth
 from app.mod_shared.models.db import db
-from app.mod_profiles.models import Measurement
+from app.mod_profiles.models import Measurement, Analysis
 from app.mod_profiles.common.fields.measurementFields import MeasurementFields
 from app.mod_profiles.common.parsers.measurement import parser_post
-from app.mod_profiles.common.swagger.responses.generic_responses import code_200_ok, code_201_created
+from app.mod_profiles.common.persistence import permission
+from app.mod_profiles.common.swagger.responses.generic_responses import code_200_ok, code_201_created, code_401, \
+    code_403
 
 
 class MeasurementList(Resource):
@@ -80,19 +84,39 @@ class MeasurementList(Resource):
             }
           ],
         responseMessages=[
-            code_201_created
+            code_201_created,
+            code_401,
+            code_403
         ]
     )
+    @auth.login_required
     @marshal_with(MeasurementFields.resource_fields, envelope='resource')
     def post(self):
+        # Obtiene los valores de los argumentos recibidos en la petición.
         args = parser_post.parse_args()
-        new_measurement = Measurement(args['datetime'],
-                                      args['value'],
-                                      args['analysis_id'],
-                                      args['profile_id'],
-                                      args['measurement_source_id'],
-                                      args['measurement_type_id'],
-                                      args['measurement_unit_id'])
+        datetime = args['datetime']
+        value = args['value']
+        analysis_id = args['analysis_id']
+        profile_id = args['profile_id']
+        measurement_source_id = args['measurement_source_id']
+        measurement_type_id = args['measurement_type_id']
+        measurement_unit_id = args['measurement_unit_id']
+
+        # Obtiene el análisis especificado.
+        if analysis_id is not None:
+            analysis = Analysis.query.get_or_404(analysis_id)
+            # Verifica que el usuario autenticado tenga permiso para editar las
+            # mediciones del análisis especificado, en caso de que exista.
+            if not permission.get_permission_by_user(analysis, g.user, 'edit_measurements'):
+                return '', 403
+
+        new_measurement = Measurement(datetime,
+                                      value,
+                                      analysis_id,
+                                      profile_id,
+                                      measurement_source_id,
+                                      measurement_type_id,
+                                      measurement_unit_id)
         db.session.add(new_measurement)
         db.session.commit()
         return new_measurement, 201

--- a/app/mod_profiles/resources/views/analysisFileDownload.py
+++ b/app/mod_profiles/resources/views/analysisFileDownload.py
@@ -6,6 +6,7 @@ from flask.ext.restful import Resource
 
 from app.mod_shared.models.auth import auth
 from app.mod_profiles.adapters.fileManagerFactory import FileManagerFactory
+from app.mod_profiles.common.persistence import permission
 from app.mod_profiles.models import AnalysisFile
 
 
@@ -14,6 +15,12 @@ class AnalysisFileDownload(Resource):
     @auth.login_required
     def get(self, id):
         analysis_file = AnalysisFile.query.get_or_404(id)
+
+        # Verifica que el usuario autenticado tenga permiso para ver los
+        # archivos de análisis, del análisis asociado.
+        if not permission.get_permission_by_user(analysis_file.analysis, g.user, 'view_analysis_files'):
+            return '', 403
+
         file_path = analysis_file.path
         file_name = file_path.rsplit('/')[-1]
         user = g.user

--- a/app/mod_profiles/resources/views/analysisView.py
+++ b/app/mod_profiles/resources/views/analysisView.py
@@ -74,13 +74,21 @@ class AnalysisView(Resource):
           ],
         responseMessages=[
             code_200_updated,
+            code_401,
+            code_403,
             code_404
         ]
     )
+    @auth.login_required
     @marshal_with(AnalysisFields.resource_fields, envelope='resource')
     def put(self, analysis_id):
         analysis = Analysis.query.get_or_404(analysis_id)
         args = parser_put.parse_args()
+
+        # Verifica que el usuario autenticado sea el dueño del análisis
+        # especificado.
+        if g.user.id != analysis.profile.user.first().id:
+            return '', 403
 
         # Actualiza los atributos del objeto, en base a los argumentos
         # recibidos.
@@ -128,11 +136,9 @@ class AnalysisView(Resource):
         # Obtiene el análisis.
         analysis = Analysis.query.get_or_404(analysis_id)
 
-        # Obtiene el usuario autenticado.
-        user = g.user
-
-        # Verifica que el usuario sea el dueño del archivo de análisis especificado.
-        if user.id != analysis.profile.user.first().id:
+        # Verifica que el usuario autenticado sea el dueño del archivo de
+        # análisis especificado.
+        if g.user.id != analysis.profile.user.first().id:
             return '', 403
 
         # Elimina todas las mediciones asociadas al análisis.

--- a/app/mod_profiles/resources/views/permissionTypeView.py
+++ b/app/mod_profiles/resources/views/permissionTypeView.py
@@ -75,14 +75,16 @@ class PermissionTypeView(Resource):
                 "required": True,
                 "dataType": "boolean",
                 "paramType": "body"
-            },{
+            },
+            {
                 "name": "can_edit_analysis_files",
                 "description": (u'Permiso para editar los archivos del '
                                 'análisis.').encode('utf-8'),
                 "required": True,
                 "dataType": "boolean",
                 "paramType": "body"
-            },{
+            },
+            {
                 "name": "can_edit_measurements",
                 "description": (u'Permiso para editar las mediciones del '
                                 'análisis.').encode('utf-8'),

--- a/app/mod_profiles/resources/views/permissionView.py
+++ b/app/mod_profiles/resources/views/permissionView.py
@@ -60,7 +60,7 @@ class PermissionView(Resource):
                 "dataType": "int",
                 "paramType": "body"
             },
-          ],
+        ],
         responseMessages=[
             code_200_updated,
             code_401,


### PR DESCRIPTION
Se implementa el **funcionamiento de los permisos** en los siguientes recursos. En todo caso, se considera al dueño del análisis con permisos totales para ver, editar y eliminar su propia información.

Recurso | Método | Usuario permitido
-------------------------------|--------------------------------------|----------------------------------
```/analysis/<analysis_id>``` | PUT, DELETE | Dueño del análisis.
```/analysis/<analysis_id>/files``` | GET | Dueño del análisis, o con permiso para **ver** los archivos de análisis.
```/analysis_files``` | POST | Dueño del análisis asociado, o con permiso para **editar** los archivos de análisis.
```/analysis_files/<analysis_file_id>``` | GET | Dueño del análisis, o con permiso para **ver** los archivos de análisis.
```/analysis_files/<analysis_file_id>``` | PUT, DELETE | Dueño del análisis, o con permiso para **editar** los archivos de análisis.
```/analysis_files/<analysis_file_id>/download``` | GET | Dueño del análisis, o con permiso para **ver** los archivos de análisis.
```/analysis/<analysis_id>/measurements``` | GET | Dueño del análisis, o con permiso para **ver** las mediciones del análisis.
```/measurements``` | POST | Dueño del análisis asociado, o con permiso para **editar** las mediciones del análisis.
```/measurements/<measurement_id>``` | PUT, DELETE | Dueño del análisis, o con permiso para **editar** las mediciones del análisis.
```/my/measurements``` | POST | Dueño del análisis asociado a la medición.
