### PR TITLE
Obtención de thumbnails desde Dropbox

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,6 +99,7 @@ api.add_resource(AnalysisCommentView, '/analysis_comments/<int:analysis_comment_
 api.add_resource(AnalysisView, '/analysis/<int:analysis_id>')
 api.add_resource(AnalysisList, '/analysis')
 api.add_resource(AnalysisFileDownload, '/analysis_files/<int:id>/download')
+api.add_resource(AnalysisFileThumbnail, '/analysis_files/<int:analysis_file_id>/thumbnail')
 api.add_resource(AnalysisFileView, '/analysis_files/<int:id>')
 api.add_resource(AnalysisFileList, '/analysis_files')
 api.add_resource(AnalysisMeasurementList, '/analysis/<int:analysis_id>/measurements')

--- a/app/mod_profiles/adapters/dropboxAdapter.py
+++ b/app/mod_profiles/adapters/dropboxAdapter.py
@@ -54,3 +54,12 @@ class DropboxAdapter(object):
             print '*** API error', err.message
             return None
         return file_metadata.name
+
+    def get_thumbnail(self, path):
+        dbx = dropbox.Dropbox(self.token)
+        try:
+            fmd, res = dbx.files_get_thumbnail(path)
+        except exceptions.ApiError as err:
+            print '*** API error', err.message
+            return None
+        return res.content

--- a/app/mod_profiles/resources/views/__init__.py
+++ b/app/mod_profiles/resources/views/__init__.py
@@ -3,6 +3,7 @@
 from .analysisCommentView import AnalysisCommentView
 from .analysisView import AnalysisView
 from .analysisFileDownload import AnalysisFileDownload
+from .analysisFileThumbnail import AnalysisFileThumbnail
 from .analysisFileView import AnalysisFileView
 from .genderView import GenderView
 from .measurementSourceView import MeasurementSourceView

--- a/app/mod_profiles/resources/views/analysisFileThumbnail.py
+++ b/app/mod_profiles/resources/views/analysisFileThumbnail.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from StringIO import StringIO
+from flask import g, send_file
+from flask.ext.restful import Resource
+
+from app.mod_shared.models.auth import auth
+from app.mod_profiles.adapters.fileManagerFactory import FileManagerFactory
+from app.mod_profiles.models import AnalysisFile
+
+
+class AnalysisFileThumbnail(Resource):
+
+    @auth.login_required
+    def get(self, analysis_file_id):
+        analysis_file = AnalysisFile.query.get_or_404(analysis_file_id)
+        file_path = analysis_file.path
+        file_name = file_path.rsplit('/')[-1]
+        file_manager = FileManagerFactory().get_file_manager(g.user)
+        file_str = file_manager.get_thumbnail(file_path)
+        str_in_out = StringIO()
+        str_in_out.write(file_str)
+        str_in_out.seek(0)
+        return send_file(str_in_out, attachment_filename=file_name)


### PR DESCRIPTION
Se crea el recurso ```/analysis_files/<analysis_file_id>/thumbnail```, para la obtención del *thumbnail* del archivo, mediante **GET**. Actualmente, sólo funciona con archivos alojados en Dropbox.