### PR TITLE
Creación de solicitud para obtener thumbnail de Dropbox, sin usar el SDK

### DIFF
--- a/app/mod_profiles/adapters/dropboxAdapter.py
+++ b/app/mod_profiles/adapters/dropboxAdapter.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import requests
 from dropbox import dropbox, exceptions
 from dropbox.files import WriteMode
 
@@ -56,10 +57,17 @@ class DropboxAdapter(object):
         return file_metadata.name
 
     def get_thumbnail(self, path):
-        dbx = dropbox.Dropbox(self.token)
+        #dbx = dropbox.Dropbox(self.token)
         try:
-            fmd, res = dbx.files_get_thumbnail(path)
-        except exceptions.ApiError as err:
-            print '*** API error', err.message
+            #fmd, res = dbx.files_get_thumbnail(path)
+            # En la versión actual de Dropbox SDK (3.37), no funciona el método
+            # para obtener el thumbnail del archivo, por lo que se solicita
+            # directamente a la API, sin hacer uso del SDK.
+            headers = {'Authorization': 'Bearer ' + self.token,
+                       'Dropbox-API-Arg': '{"path": "' + path + '", "format": "jpeg", "size": "w640h480"}'}
+            res = requests.post("https://content.dropboxapi.com/2/files/get_thumbnail",
+                                headers=headers)
+        except:
+            # print '*** API error', err.message
             return None
         return res.content

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==0.7.6
 aniso8601==1.0.0
-dropbox==3.34
+dropbox==3.37
 Flask==0.10.1
 Flask-Cors==2.0.1
 Flask-HTTPAuth==2.6.0
@@ -19,8 +19,8 @@ passlib==1.6.5
 psycopg2==2.6
 python-dateutil==2.4.2
 pytz==2015.4
-requests==2.7.0
-six==1.9.0
+requests==2.8.1
+six==1.10.0
 SQLAlchemy==1.0.4
 urllib3==1.12
 Werkzeug==0.10.4


### PR DESCRIPTION
En la versión actual de [dropbox/dropbox-sdk-python](https://github.com/dropbox/dropbox-sdk-python) (**3.37**), el método para obtener el **thumbnail** de una imagen no funciona, debido a problemas con *ThumbnailSize*.

Por esto, se implementa el *request* **sin hacer uso del SDK**. El thumbnail se solicita con un tamaño de **640x480**.