### PR TITLE
Verificación de permisos en recurso de obtención de thumbnail

### DIFF
--- a/app/mod_profiles/resources/views/analysisFileThumbnail.py
+++ b/app/mod_profiles/resources/views/analysisFileThumbnail.py
@@ -6,6 +6,7 @@ from flask.ext.restful import Resource
 
 from app.mod_shared.models.auth import auth
 from app.mod_profiles.adapters.fileManagerFactory import FileManagerFactory
+from app.mod_profiles.common.persistence import permission
 from app.mod_profiles.models import AnalysisFile
 
 
@@ -14,6 +15,12 @@ class AnalysisFileThumbnail(Resource):
     @auth.login_required
     def get(self, analysis_file_id):
         analysis_file = AnalysisFile.query.get_or_404(analysis_file_id)
+
+        # Verifica que el usuario autenticado tenga permiso para ver los
+        # archivos de análisis, del análisis asociado.
+        if not permission.get_permission_by_user(analysis_file.analysis, g.user, 'view_analysis_files'):
+            return '', 403
+
         file_path = analysis_file.path
         file_name = file_path.rsplit('/')[-1]
         file_manager = FileManagerFactory().get_file_manager(g.user)


### PR DESCRIPTION
Se añade la verificación de permisos en el recurso ```/analysis_files/<analysis_file_id>/thumbnail```