### PR TITLE
Configuración de nosetests para Shippable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ itsdangerous==0.24
 Jinja2==2.7.3
 Mako==1.0.1
 MarkupSafe==0.23
+nose==1.3.7
 passlib==1.6.5
 psycopg2==2.6
 python-dateutil==2.4.2

--- a/shippable.yml
+++ b/shippable.yml
@@ -5,3 +5,10 @@ python:
 
 install:
     - pip install -r requirements.txt
+
+before_script:
+    - psql -c 'create database salud_test;' -U postgres
+    - mkdir -p shippable/testresults
+
+script:
+    - nosetests tests --with-xunit --xunit-file=shippable/testresults/nosetests.xml

--- a/shippable.yml
+++ b/shippable.yml
@@ -6,6 +6,9 @@ python:
 install:
     - pip install -r requirements.txt
 
+env:
+    - FLASK_CONFIG_MODE="testing"
+
 before_script:
     - psql -c 'create database salud_test;' -U postgres
     - mkdir -p shippable/testresults


### PR DESCRIPTION
Se instala ```nose```, y se configura **Shippable** para que ejecute los tests mediante ```nosetests```.