### PR TITLE
Eliminación del requerimiento de campo 'password' en recursos PUT para edición de usuarios

### DIFF
--- a/app/mod_profiles/common/parsers/user.py
+++ b/app/mod_profiles/common/parsers/user.py
@@ -17,3 +17,5 @@ parser_post = parser.copy()
 
 # Parser para recurso PUT
 parser_put = parser.copy()
+parser_put.remove_argument('password')
+parser_put.add_argument('password', type=str)

--- a/app/mod_profiles/common/persistence/user.py
+++ b/app/mod_profiles/common/persistence/user.py
@@ -33,6 +33,7 @@ def update(user, username=None, email=None, password=None, profile_id=None):
         user.email = email
     # Actualiza la contraseña, en caso de que haya sido modificado.
     if (password is not None and
+          len(password) > 0 and
           not user.verify_password(password)):
         user.hash_password(password)
     # Actualiza el perfil asociado, en caso de que haya sido modificado.


### PR DESCRIPTION
Se deja el argumento ```password``` como opcional para los recursos ```/users/<id>``` y ```/my/user```, en su método **PUT**.