### PR TITLE
Creación de validador para variables booleanas

### DIFF
--- a/app/mod_profiles/common/parsers/measurementUnit.py
+++ b/app/mod_profiles/common/parsers/measurementUnit.py
@@ -2,14 +2,14 @@
 
 from flask_restful import reqparse
 
-from app.mod_profiles.validators.generic_validators import string_without_int
+from app.mod_profiles.validators.generic_validators import is_boolean, string_without_int
 
 
 # Parser general
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=string_without_int, required=True)
 parser.add_argument('symbol', type=string_without_int, required=True)
-parser.add_argument('suffix', type=bool)
+parser.add_argument('suffix', type=is_boolean)
 
 # Parser para recurso POST
 parser_post = parser.copy()

--- a/app/mod_profiles/common/parsers/permissionType.py
+++ b/app/mod_profiles/common/parsers/permissionType.py
@@ -2,17 +2,17 @@
 
 from flask_restful import reqparse
 
-from app.mod_profiles.validators.generic_validators import string_without_int
+from app.mod_profiles.validators.generic_validators import is_boolean, string_without_int
 
 
 # Parser general
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=string_without_int, required=True)
 parser.add_argument('description', type=str)
-parser.add_argument('can_view_analysis_files', type=bool, required=True)
-parser.add_argument('can_view_measurements', type=bool, required=True)
-parser.add_argument('can_edit_analysis_files', type=bool, required=True)
-parser.add_argument('can_edit_measurements', type=bool, required=True)
+parser.add_argument('can_view_analysis_files', type=is_boolean, required=True)
+parser.add_argument('can_view_measurements', type=is_boolean, required=True)
+parser.add_argument('can_edit_analysis_files', type=is_boolean, required=True)
+parser.add_argument('can_edit_measurements', type=is_boolean, required=True)
 
 # Parser para recurso POST
 parser_post = parser.copy()

--- a/app/mod_profiles/validators/generic_validators.py
+++ b/app/mod_profiles/validators/generic_validators.py
@@ -209,3 +209,15 @@ def is_valid_image_file(var):
         raise ValueError("El formato de archivo no corresponde, pruebe con \"jpg\"")
     return var
 
+
+def is_boolean(var):
+    true_values = ['true', '1']
+    false_values = ['false', '0']
+
+    var = str(var).lower()
+    if var in true_values:
+        return True
+    elif var in false_values:
+        return False
+
+    raise ValueError("El valor ingresado debe ser booleano.")


### PR DESCRIPTION
Se crea un **validador de variables booleanas** para los recursos de la API. Los valores aceptados son:

* Cadenas: ```"True"``` y ```"False"``` (sin distinguir mayúsculas y minúsculas).
* Enteros: ```1``` y ```0```.

Además, se hace uso de este validador en los parsers de  ```PermissionType``` y de ```MeasurementUnit```.