### PR TITLE
Especificación de análisis opcional para la medición

### DIFF
--- a/app/mod_profiles/common/parsers/measurement.py
+++ b/app/mod_profiles/common/parsers/measurement.py
@@ -9,7 +9,7 @@ from app.mod_profiles.validators.generic_validators import is_valid_id, is_valid
 parser = reqparse.RequestParser()
 parser.add_argument('datetime', type=is_valid_previous_datetime, required=True)
 parser.add_argument('value', type=float, required=True)
-parser.add_argument('analysis_id', type=is_valid_id, required=True)
+parser.add_argument('analysis_id', type=is_valid_id)
 parser.add_argument('profile_id', type=is_valid_id, required=True)
 parser.add_argument('measurement_source_id', type=is_valid_id)
 parser.add_argument('measurement_type_id', type=is_valid_id, required=True)

--- a/app/mod_profiles/resources/lists/measurementList.py
+++ b/app/mod_profiles/resources/lists/measurementList.py
@@ -50,7 +50,7 @@ class MeasurementList(Resource):
             {
               "name": "analysis_id",
               "description": u'Identificador único del análisis asociado.'.encode('utf-8'),
-              "required": True,
+              "required": False,
               "dataType": "int",
               "paramType": "body"
             },

--- a/app/mod_profiles/resources/lists/myMeasurementList.py
+++ b/app/mod_profiles/resources/lists/myMeasurementList.py
@@ -107,7 +107,7 @@ class MyMeasurementList(Resource):
             {
               "name": "analysis_id",
               "description": u'Identificador único del análisis asociado.'.encode('utf-8'),
-              "required": True,
+              "required": False,
               "dataType": "int",
               "paramType": "body"
             },
@@ -151,16 +151,16 @@ class MyMeasurementList(Resource):
         measurement_type_id = args['measurement_type_id']
         measurement_unit_id = args['measurement_unit_id']
 
-        # Obtiene el análisis.
-        analysis = Analysis.query.get_or_404(analysis_id)
-
-        # Verifica que el usuario sea el dueño del análisis especificado.
-        if g.user.id != analysis.profile.user.first().id:
-            return '', 403
+        # Obtiene el análisis especificado.
+        if analysis_id is not None:
+            analysis = Analysis.query.get_or_404(analysis_id)
+            # Verifica que el usuario sea el dueño del análisis especificado.
+            if g.user.id != analysis.profile.user.first().id:
+                return '', 403
 
         new_measurement = Measurement(datetime,
                                       value,
-                                      analysis.id,
+                                      analysis_id,
                                       g.user.profile.id,
                                       measurement_source_id,
                                       measurement_type_id,

--- a/app/mod_profiles/resources/views/measurementView.py
+++ b/app/mod_profiles/resources/views/measurementView.py
@@ -67,7 +67,7 @@ class MeasurementView(Resource):
             {
               "name": "analysis_id",
               "description": u'Identificador único del análisis asociado.'.encode('utf-8'),
-              "required": True,
+              "required": False,
               "dataType": "int",
               "paramType": "body"
             },


### PR DESCRIPTION
Se establece como **opcional** el parámetro ```analysis_id``` para los recursos ```/measurements``` y ```/my/measurements``` mediante método **POST**, y el recurso ```/measurements/<id>``` mediante método **PUT**.