### PR TITLE
Especificación de 'flush' en sesión de base de datos

### DIFF
--- a/app/mod_profiles/resources/lists/analysisPermissionList.py
+++ b/app/mod_profiles/resources/lists/analysisPermissionList.py
@@ -103,6 +103,7 @@ class AnalysisPermissionList(Resource):
                                     permission_type_id,
                                     user_id)
         db.session.add(new_permission)
+        db.session.flush()
 
         # Crea la notificación dirigida a quien se le ha compartido el análisis.
         notification = NotificationNewSharedAnalysis(user.profile.id,

--- a/app/mod_profiles/resources/lists/groupGroupMembershipList.py
+++ b/app/mod_profiles/resources/lists/groupGroupMembershipList.py
@@ -158,6 +158,7 @@ class GroupGroupMembershipList(Resource):
                                                g.user.profile.id
                                                )
         db.session.add(new_group_membership)
+        db.session.flush()
 
         # Crea la notificación dirigida al nuevo miembro del grupo.
         notification = NotificationNewGroupMembership(user.profile.id,

--- a/app/mod_profiles/resources/lists/groupList.py
+++ b/app/mod_profiles/resources/lists/groupList.py
@@ -81,6 +81,7 @@ class GroupList(Resource):
         new_group = Group(name,
                           description)
         db.session.add(new_group)
+        db.session.flush()
 
         # Crea la membresía asociada al nuevo grupo y al perfil del usuario
         # autenticado.


### PR DESCRIPTION
Para poder utilizar el atributo ```id``` del **recurso recién creado**, antes de realizar ```commit```, se debe efectuar un ```flush``` de la sesión de la base de datos.