### PR TITLE
Corrección en asociación de nueva membresía a perfil especificado

### DIFF
--- a/app/mod_profiles/resources/lists/groupGroupMembershipList.py
+++ b/app/mod_profiles/resources/lists/groupGroupMembershipList.py
@@ -155,7 +155,7 @@ class GroupGroupMembershipList(Resource):
                                                group.id,
                                                group_membership_type.id,
                                                permission_type.id,
-                                               g.user.profile.id
+                                               user.profile.id
                                                )
         db.session.add(new_group_membership)
         db.session.flush()


### PR DESCRIPTION
Se corrige la creación de nuevas membresías a un grupo, que **generaba la membresía asociada al usuario autenticado**, y no al perfil del usuario especificado mediante **POST** en ```/groups/<group_id>/members```.