### PR TITLE
Especificación de relaciones backref con comportamiento en cascada

### DIFF
--- a/app/mod_profiles/models/AnalysisComment.py
+++ b/app/mod_profiles/models/AnalysisComment.py
@@ -13,7 +13,11 @@ class AnalysisComment(db.Model):
     profile_id  = db.Column(db.Integer, db.ForeignKey('profile.id'))
     # Relationships
     analysis = db.relationship('Analysis',
-                               backref=db.backref('analysis_comments', lazy='dynamic'))
+                               backref=db.backref('analysis_comments',
+                                                  lazy='dynamic',
+                                                  cascade='all, delete-orphan',
+                                                  )
+                               )
     profile  = db.relationship('Profile',
                                backref=db.backref('analysis_comments', lazy='dynamic'))
 

--- a/app/mod_profiles/models/AnalysisFile.py
+++ b/app/mod_profiles/models/AnalysisFile.py
@@ -14,7 +14,11 @@ class AnalysisFile(db.Model):
     storage_location_id = db.Column(db.Integer, db.ForeignKey('storage_location.id'))
     # Relationships
     analysis         = db.relationship('Analysis',
-                                       backref=db.backref('analysis_files', lazy='dynamic'))
+                                       backref=db.backref('analysis_files',
+                                                          lazy='dynamic',
+                                                          cascade='all, delete-orphan',
+                                                          )
+                                       )
     storage_location = db.relationship('StorageLocation',
                                        backref=db.backref('analysis_files', lazy='dynamic'))
 

--- a/app/mod_profiles/models/GroupMembership.py
+++ b/app/mod_profiles/models/GroupMembership.py
@@ -14,7 +14,11 @@ class GroupMembership(db.Model):
     profile_id               = db.Column(db.Integer, db.ForeignKey('profile.id'))
     # Relationships
     group                 = db.relationship('Group',
-                                            backref=db.backref('memberships', lazy='dynamic'))
+                                            backref=db.backref('memberships',
+                                                               lazy='dynamic',
+                                                               cascade='all, delete-orphan',
+                                                               )
+                                            )
     group_membership_type = db.relationship('GroupMembershipType',
                                             backref=db.backref('memberships', lazy='dynamic'))
     permission_type       = db.relationship('PermissionType',

--- a/app/mod_profiles/models/Measurement.py
+++ b/app/mod_profiles/models/Measurement.py
@@ -16,7 +16,11 @@ class Measurement(db.Model):
     measurement_unit_id   = db.Column(db.Integer, db.ForeignKey('measurement_unit.id'))
     # Relationships
     analysis           = db.relationship('Analysis',
-                                         backref=db.backref('measurements', lazy='dynamic'))
+                                         backref=db.backref('measurements',
+                                                            lazy='dynamic',
+                                                            cascade='all',
+                                                            )
+                                         )
     profile            = db.relationship('Profile',
                                          backref=db.backref('measurements', lazy='dynamic'))
     measurement_source = db.relationship('MeasurementSource',

--- a/app/mod_profiles/models/NotificationNewAnalysisFromGroup.py
+++ b/app/mod_profiles/models/NotificationNewAnalysisFromGroup.py
@@ -11,8 +11,18 @@ class NotificationNewAnalysisFromGroup(Notification):
     analysis_id = db.Column(db.Integer, db.ForeignKey('analysis.id'))
     group_id    = db.Column(db.Integer, db.ForeignKey('group.id'))
     # Relationships
-    analysis = db.relationship('Analysis')
-    group    = db.relationship('Group')
+    analysis = db.relationship('Analysis',
+                               backref=db.backref('notifications',
+                                                  lazy='dynamic',
+                                                  cascade='all, delete-orphan'
+                                                  )
+                               )
+    group    = db.relationship('Group',
+                               backref=db.backref('notifications',
+                                                  lazy='dynamic',
+                                                  cascade='all, delete-orphan',
+                                                  )
+                               )
 
     __mapper_args__ = {
         'polymorphic_identity': 'notificationNewAnalysisFromGroup',

--- a/app/mod_profiles/models/NotificationNewGroupMembership.py
+++ b/app/mod_profiles/models/NotificationNewGroupMembership.py
@@ -11,7 +11,12 @@ class NotificationNewGroupMembership(Notification):
     group_membership_id = db.Column(db.Integer, db.ForeignKey('group_membership.id'))
     profile_id          = db.Column(db.Integer, db.ForeignKey('profile.id'))
     # Relationships
-    group_membership = db.relationship('GroupMembership')
+    group_membership = db.relationship('GroupMembership',
+                                       backref=db.backref('notifications',
+                                                          lazy='dynamic',
+                                                          cascade='all, delete-orphan',
+                                                          )
+                                       )
     profile          = db.relationship('Profile')
 
     __mapper_args__ = {

--- a/app/mod_profiles/models/NotificationNewSharedAnalysis.py
+++ b/app/mod_profiles/models/NotificationNewSharedAnalysis.py
@@ -11,7 +11,12 @@ class NotificationNewSharedAnalysis(Notification):
     permission_id = db.Column(db.Integer, db.ForeignKey('permission.id'))
     profile_id    = db.Column(db.Integer, db.ForeignKey('profile.id'))
     # Relationships
-    permission = db.relationship('Permission')
+    permission = db.relationship('Permission',
+                                 backref=db.backref('notifications',
+                                                    lazy='dynamic',
+                                                    cascade='all, delete-orphan',
+                                                    )
+                                 )
     profile    = db.relationship('Profile')
 
     __mapper_args__ = {

--- a/app/mod_profiles/models/Permission.py
+++ b/app/mod_profiles/models/Permission.py
@@ -12,7 +12,11 @@ class Permission(db.Model):
     user_id            = db.Column(db.Integer, db.ForeignKey('user.id'))
     # Relationships
     analysis        = db.relationship('Analysis',
-                                      backref=db.backref('permissions', lazy='dynamic'))
+                                      backref=db.backref('permissions',
+                                                         lazy='dynamic',
+                                                         cascade='all, delete-orphan',
+                                                         )
+                                      )
     permission_type = db.relationship('PermissionType',
                                       backref=db.backref('permissions', lazy='dynamic'))
     user            = db.relationship('User',

--- a/app/mod_profiles/resources/views/analysisView.py
+++ b/app/mod_profiles/resources/views/analysisView.py
@@ -141,17 +141,11 @@ class AnalysisView(Resource):
         if g.user.id != analysis.profile.user.first().id:
             return '', 403
 
-        # Elimina todas las mediciones asociadas al análisis.
-        measurements = analysis.measurements.all()
-        for measurement in measurements:
-            db.session.delete(measurement)
-
         # Elimina todos los archivos de análisis asociados al análisis.
         analysis_files = analysis.analysis_files.all()
         for analysis_file in analysis_files:
             # Elimina el archivo asociado de la ubicación de almacenamiento.
             analysisFile.delete_file(analysis_file)
-            db.session.delete(analysis_file)
 
         # Elimina el análisis.
         db.session.delete(analysis)

--- a/app/mod_profiles/resources/views/groupView.py
+++ b/app/mod_profiles/resources/views/groupView.py
@@ -140,13 +140,6 @@ class GroupView(Resource):
         if not group_persistence.is_group_admin(group, g.user):
             return '', 403
 
-        # Obtiene todas las membresías del grupo
-        group_memberships = group.memberships.all()
-
-        # Elimina todas las membresías asociadas al grupo.
-        for membership in group_memberships:
-            db.session.delete(membership)
-
         # Elimina el grupo.
         db.session.delete(group)
         db.session.commit()


### PR DESCRIPTION
Se especifican en las relaciones *backref* existentes que corresponde, el **comportamiento en cascada** **[1]**, especialmente para las operaciones de eliminación (*delete*). Además, se elimina la lógica existente en los recursos de la API, que se resuelven automáticamente con el comportamiento en cascada.

**[1]** http://docs.sqlalchemy.org/en/rel_1_0/orm/cascades.html