### PR TITLE
Corrección en navegación de Profile a User

### DIFF
--- a/app/mod_profiles/common/persistence/analysisFile.py
+++ b/app/mod_profiles/common/persistence/analysisFile.py
@@ -20,7 +20,7 @@ def delete_file(analysis_file):
         raise ValueError("El archivo de análisis especificado es incorrecto.")
 
     # Obtiene el usuario asociado al archivo de análisis.
-    user = analysis_file.analysis.profile.user
+    user = analysis_file.analysis.profile.user.first()
 
     # Obtiene la ubicación de almacenamiento asociado al archivo de análisis.
     file_manager = FileManagerFactory().get_file_manager(user)


### PR DESCRIPTION
Se corrige la navegación mediante *backref* entre **Profile** y **User**, en el método para eliminar un archivo de análisis en su ubicación de almacenamiento.