### PR TITLE
Formato correcto de comillas en descripciones de notificaciones

### DIFF
--- a/app/mod_profiles/models/NotificationNewAnalysisFromGroup.py
+++ b/app/mod_profiles/models/NotificationNewAnalysisFromGroup.py
@@ -37,8 +37,8 @@ class NotificationNewAnalysisFromGroup(Notification):
         return u'¡Han cargado un nuevo análisis en un grupo!'
 
     def get_description(self):
-        description = (u"Un nuevo análisis, con el nombre \"%s\", ha sido "
-                       "cargado en el grupo \"%s\".") % (
+        description = (u'Un nuevo análisis, con el nombre "%s", ha sido '
+                       'cargado en el grupo "%s".') % (
             self.analysis.description,
             self.group.name,
         )

--- a/app/mod_profiles/models/NotificationNewGroupMembership.py
+++ b/app/mod_profiles/models/NotificationNewGroupMembership.py
@@ -32,7 +32,7 @@ class NotificationNewGroupMembership(Notification):
         return u'¡Te han agregado a un grupo!'
 
     def get_description(self):
-        description = u"%s te ha agregado al grupo \"%s\"." % (
+        description = u'%s te ha agregado al grupo "%s".' % (
             self.profile.first_name + " " + self.profile.last_name,
             self.group_membership.group.name,
         )

--- a/app/mod_profiles/models/NotificationNewSharedAnalysis.py
+++ b/app/mod_profiles/models/NotificationNewSharedAnalysis.py
@@ -32,7 +32,7 @@ class NotificationNewSharedAnalysis(Notification):
         return u'¡Han compartido un análisis contigo!'
 
     def get_description(self):
-        description = u"%s ha compartido el análisis \"%s\" contigo." % (
+        description = u'%s ha compartido el análisis "%s" contigo.' % (
             self.profile.first_name + " " + self.profile.last_name,
             self.permission.analysis.description,
         )


### PR DESCRIPTION
Se corrigió el formato de las descripciones de notificación, para **escapar correctamente las comillas**.