### PR TITLE
Obtención de thumbnail para archivos de análisis encriptados

### DIFF
--- a/app/mod_profiles/resources/views/analysisFileThumbnail.py
+++ b/app/mod_profiles/resources/views/analysisFileThumbnail.py
@@ -6,7 +6,7 @@ from flask.ext.restful import Resource
 
 from app.mod_shared.models.auth import auth
 from app.mod_profiles.adapters.fileManagerFactory import FileManagerFactory
-from app.mod_profiles.common.persistence import permission
+from app.mod_profiles.common.persistence import encryption, permission
 from app.mod_profiles.models import AnalysisFile
 
 
@@ -24,7 +24,29 @@ class AnalysisFileThumbnail(Resource):
         file_path = analysis_file.path
         file_name = file_path.rsplit('/')[-1]
         file_manager = FileManagerFactory().get_file_manager(g.user)
-        file_str = file_manager.get_thumbnail(file_path)
+
+        # Verifica si el archivo de análisis está encriptado. De ser así,
+        # recupera el archivo original. Sino, solicita su thumbnail a la
+        # ubicación de almacenamiento.
+        if analysis_file.is_encrypted:
+            file_str = file_manager.download_file(file_path)
+            # Obtiene la instancia de AnalysisFileEncryption, que fue generada
+            # al encriptar el archivo.
+            analysis_file_encryption = analysis_file.analysis_file_encryptions.first()
+            # Obtiene la clave secreta encriptada.
+            encrypted_secret_key = analysis_file_encryption.encrypted_secret_key
+            # Obtiene la clave RSA privada del usuario que encriptó el archivo.
+            rsa_private_key = analysis_file_encryption.profile.user.first().rsa_private_key
+            # Desencripta la clave secreta con la clave RSA privada del usuario
+            # que encriptó el archivo.
+            secret_key = encryption.decrypt_secret_key(encrypted_secret_key,
+                                                       rsa_private_key
+                                                       )
+            # Desencripta el archivo haciendo uso de la clave secreta.
+            file_str = encryption.decrypt_file(file_str, secret_key)
+        else:
+            file_str = file_manager.get_thumbnail(file_path)
+
         str_in_out = StringIO()
         str_in_out.write(file_str)
         str_in_out.seek(0)

--- a/app/mod_profiles/resources/views/analysisFileThumbnailByQuery.py
+++ b/app/mod_profiles/resources/views/analysisFileThumbnailByQuery.py
@@ -6,7 +6,7 @@ from flask.ext.restful import Resource
 from flask_restful import reqparse
 
 from app.mod_profiles.adapters.fileManagerFactory import FileManagerFactory
-from app.mod_profiles.common.persistence import permission
+from app.mod_profiles.common.persistence import encryption, permission
 from app.mod_profiles.models import AnalysisFile, User
 
 
@@ -38,7 +38,29 @@ class AnalysisFileThumbnailByQuery(Resource):
         file_path = analysis_file.path
         file_name = file_path.rsplit('/')[-1]
         file_manager = FileManagerFactory().get_file_manager(user)
-        file_str = file_manager.get_thumbnail(file_path)
+
+        # Verifica si el archivo de análisis está encriptado. De ser así,
+        # recupera el archivo original. Sino, solicita su thumbnail a la
+        # ubicación de almacenamiento.
+        if analysis_file.is_encrypted:
+            file_str = file_manager.download_file(file_path)
+            # Obtiene la instancia de AnalysisFileEncryption, que fue generada
+            # al encriptar el archivo.
+            analysis_file_encryption = analysis_file.analysis_file_encryptions.first()
+            # Obtiene la clave secreta encriptada.
+            encrypted_secret_key = analysis_file_encryption.encrypted_secret_key
+            # Obtiene la clave RSA privada del usuario que encriptó el archivo.
+            rsa_private_key = analysis_file_encryption.profile.user.first().rsa_private_key
+            # Desencripta la clave secreta con la clave RSA privada del usuario
+            # que encriptó el archivo.
+            secret_key = encryption.decrypt_secret_key(encrypted_secret_key,
+                                                       rsa_private_key
+                                                       )
+            # Desencripta el archivo haciendo uso de la clave secreta.
+            file_str = encryption.decrypt_file(file_str, secret_key)
+        else:
+            file_str = file_manager.get_thumbnail(file_path)
+
         str_in_out = StringIO()
         str_in_out.write(file_str)
         str_in_out.seek(0)


### PR DESCRIPTION
Se añade **soporte para archivos de análisis encriptados**, al solicitar su *thumbnail*. Debido a que el archivo se encuentra encriptado en su ubicación de almacenamiento, **el mismo se desencripta y se retorna en su forma original**, no mediante un thumbnail del mismo.

Los recursos de la API afectados son:
* ```/analysis_files/<analysis_file_id>/thumbnail``` (*GET*)
* ```/analysis_files/<analysis_file_id>/thumbnail_by_query``` (*GET*)