### PR TITLE
Filtrado de membresías de grupo propias, por grupo

### DIFF
--- a/app/mod_profiles/common/parsers/profileGroupMembership.py
+++ b/app/mod_profiles/common/parsers/profileGroupMembership.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from flask_restful import reqparse
+
+from app.mod_profiles.validators.generic_validators import is_valid_id
+
+
+# Parser general
+parser = reqparse.RequestParser()
+parser.add_argument('group', type=is_valid_id)
+
+# Parser para recurso GET
+parser_get = parser.copy()

--- a/app/mod_profiles/resources/lists/myGroupMembershipList.py
+++ b/app/mod_profiles/resources/lists/myGroupMembershipList.py
@@ -6,6 +6,7 @@ from flask_restful_swagger import swagger
 
 from app.mod_shared.models.auth import auth
 from app.mod_profiles.common.fields.groupMembershipFields import GroupMembershipFields
+from app.mod_profiles.common.parsers.profileGroupMembership import parser_get
 from app.mod_profiles.common.swagger.responses.generic_responses import code_200_found, code_401, code_404
 
 
@@ -16,6 +17,17 @@ class MyGroupMembershipList(Resource):
                'grupo, del usuario autenticado.').encode('utf-8'),
         responseClass='GroupMembershipFields',
         nickname='myGroupMembershipList_get',
+        parameters=[
+            {
+                "name": "group",
+                "description": (u'Identificador único del grupo. Permite '
+                                'filtrar las membresías, para sólo obtener '
+                                'las asociadas al grupo especificado.').encode('utf-8'),
+                "required": False,
+                "dataType": "int",
+                "paramType": "query"
+            },
+        ],
         responseMessages=[
             code_200_found,
             code_401,
@@ -28,7 +40,16 @@ class MyGroupMembershipList(Resource):
         # Obtiene el perfil.
         profile = g.user.profile
 
-        # Obtiene todas las membresías de grupo asociadas al perfil.
-        profile_memberships = profile.memberships.all()
+        # Obtiene los valores de los argumentos recibidos en la petición.
+        args = parser_get.parse_args()
+        group_id = args['group']
 
+        # Obtiene todas las membresías de grupo asociadas al perfil.
+        profile_memberships = profile.memberships
+
+        # Filtra las membresías por grupo.
+        if group_id is not None:
+            profile_memberships = profile_memberships.filter_by(group_id=group_id)
+
+        profile_memberships = profile_memberships.all()
         return profile_memberships


### PR DESCRIPTION
Se añade al recurso ```/my/group_memberships``` (método **GET**) un parámetro *query* opcional de tipo entero: ```group```. El mismo permite filtrar las membresías a partir del identificador único de un grupo.