### PR TITLE
Solicitud de autenticación en recurso para eliminar permiso

### DIFF
--- a/app/mod_profiles/resources/views/permissionView.py
+++ b/app/mod_profiles/resources/views/permissionView.py
@@ -114,6 +114,7 @@ class PermissionView(Resource):
             code_404
         ]
     )
+    @auth.login_required
     @marshal_with(PermissionFields.resource_fields, envelope='resource')
     def delete(self, permission_id):
         # Obtiene el permiso.


### PR DESCRIPTION
Se añade la especificación de que el recurso para eliminar un permiso (**DELETE** en ```/permissions/<permission_id>```) requiere autenticación.