### PR TITLE
Obtención de imagen y thumbnail en análisis compartidos

### DIFF
--- a/app/mod_profiles/resources/lists/analysisFileList.py
+++ b/app/mod_profiles/resources/lists/analysisFileList.py
@@ -107,7 +107,7 @@ class AnalysisFileList(Resource):
             # Encripta el archivo haciendo uso de la clave secreta.
             image_file = encryption.encrypt_file(image_file, secret_key)
 
-        file_manager = FileManagerFactory().get_file_manager(g.user)
+        file_manager = FileManagerFactory().get_file_manager(analysis.profile.user.first())
         res = file_manager.upload_file(image_file)
         storage_location = StorageLocation.query.filter_by(name=res['storage_location']).first()
         if storage_location is None:

--- a/app/mod_profiles/resources/views/analysisFileDownload.py
+++ b/app/mod_profiles/resources/views/analysisFileDownload.py
@@ -24,7 +24,7 @@ class AnalysisFileDownload(Resource):
         file_path = analysis_file.path
         file_name = file_path.rsplit('/')[-1]
         user = g.user
-        file_manager = FileManagerFactory().get_file_manager(user)
+        file_manager = FileManagerFactory().get_file_manager(analysis_file.analysis.profile.user.first())
         file_str = file_manager.download_file(file_path)
 
         if analysis_file.is_encrypted:

--- a/app/mod_profiles/resources/views/analysisFileThumbnail.py
+++ b/app/mod_profiles/resources/views/analysisFileThumbnail.py
@@ -23,7 +23,7 @@ class AnalysisFileThumbnail(Resource):
 
         file_path = analysis_file.path
         file_name = file_path.rsplit('/')[-1]
-        file_manager = FileManagerFactory().get_file_manager(g.user)
+        file_manager = FileManagerFactory().get_file_manager(analysis_file.analysis.profile.user.first())
 
         # Verifica si el archivo de análisis está encriptado. De ser así,
         # recupera el archivo original. Sino, solicita su thumbnail a la

--- a/app/mod_profiles/resources/views/analysisFileThumbnailByQuery.py
+++ b/app/mod_profiles/resources/views/analysisFileThumbnailByQuery.py
@@ -40,7 +40,7 @@ class AnalysisFileThumbnailByQuery(Resource):
 
         file_path = analysis_file.path
         file_name = file_path.rsplit('/')[-1]
-        file_manager = FileManagerFactory().get_file_manager(user)
+        file_manager = FileManagerFactory().get_file_manager(analysis_file.analysis.profile.user.first())
 
         # Verifica si el archivo de análisis está encriptado. De ser así,
         # recupera el archivo original. Sino, solicita su thumbnail a la


### PR DESCRIPTION
La obtención de las imágenes de archivos de análisis, y sus respectivos *thumbnails*, fallaba debido a que **se hacía uso de las credenciales de almacenamiento del usuario autenticado**. Por lo tanto, al querer acceder a las mismas mediante un usuario a quien se le ha compartido el análisis, no se encontraban las credenciales correctas, y la imagen no podía ser recuperada.

La solución fue **hacer uso de las credenciales del usuario dueño del análisis**.