### PR TITLE
Especificación de tipos de notificación

### DIFF
--- a/app/mod_profiles/common/fields/notificationFields.py
+++ b/app/mod_profiles/common/fields/notificationFields.py
@@ -18,6 +18,7 @@ class NotificationFields:
         'description': fields.String,
         'detail_object_type': fields.String,
         'detail_object_id': fields.Integer,
+        'notification_type': fields.String,
     }
 
     required = [
@@ -29,4 +30,5 @@ class NotificationFields:
         'description',
         'detail_object_type',
         'detail_object_id',
+        'notification_type',
     ]

--- a/app/mod_profiles/common/parsers/notification.py
+++ b/app/mod_profiles/common/parsers/notification.py
@@ -8,6 +8,7 @@ from app.mod_profiles.validators.generic_validators import is_boolean, positive_
 # Parser general
 parser = reqparse.RequestParser()
 parser.add_argument('quantity', type=positive_int)
+parser.add_argument('type', type=str)
 parser.add_argument('unread', type=is_boolean)
 
 # Parser para recurso GET

--- a/app/mod_profiles/models/Notification.py
+++ b/app/mod_profiles/models/Notification.py
@@ -42,5 +42,8 @@ class Notification(db.Model):
     def get_detail_object_id(self):
         raise NotImplementedError(u'Método no implementado.')
 
+    def get_notification_type(self):
+        raise NotImplementedError(u'Método no implementado.')
+
     def __repr__(self):
         return '<Notification: %r>' % self.id

--- a/app/mod_profiles/models/NotificationNewAnalysisComment.py
+++ b/app/mod_profiles/models/NotificationNewAnalysisComment.py
@@ -45,5 +45,9 @@ class NotificationNewAnalysisComment(Notification):
     def get_detail_object_id(self):
         return self.analysis_comment.analysis.id
 
+    @staticmethod
+    def get_notification_type():
+        return 'message'
+
     def __repr__(self):
         return '<NotificationNewAnalysisComment: %r>' % self.id

--- a/app/mod_profiles/models/NotificationNewAnalysisFromGroup.py
+++ b/app/mod_profiles/models/NotificationNewAnalysisFromGroup.py
@@ -54,5 +54,9 @@ class NotificationNewAnalysisFromGroup(Notification):
     def get_detail_object_id(self):
         return self.analysis.id
 
+    @staticmethod
+    def get_notification_type():
+        return 'event'
+
     def __repr__(self):
         return '<NotificationNewAnalysisFromGroup: %r>' % self.id

--- a/app/mod_profiles/models/NotificationNewGroupMembership.py
+++ b/app/mod_profiles/models/NotificationNewGroupMembership.py
@@ -48,5 +48,9 @@ class NotificationNewGroupMembership(Notification):
     def get_detail_object_id(self):
         return self.group_membership.group.id
 
+    @staticmethod
+    def get_notification_type():
+        return 'event'
+
     def __repr__(self):
         return '<NotificationNewGroupMembership: %r>' % self.id

--- a/app/mod_profiles/models/NotificationNewSharedAnalysis.py
+++ b/app/mod_profiles/models/NotificationNewSharedAnalysis.py
@@ -48,5 +48,9 @@ class NotificationNewSharedAnalysis(Notification):
     def get_detail_object_id(self):
         return self.permission.analysis.id
 
+    @staticmethod
+    def get_notification_type():
+        return 'event'
+
     def __repr__(self):
         return '<NotificationNewSharedAnalysis: %r>' % self.id


### PR DESCRIPTION
Se añade la especificación del **tipo de notificación**, dividiéndolas en notificaciones de tipo ```message``` (actualmente, sólo los comentarios hechos a un análisis) y tipo ```event```. Además, se añade al recurso de la API ```/my/notifications``` (método **GET**), la posibilidad de especificar el siguiente **parámetro *query* opcional**:

* ```type```: Tipo de notificaciones a retornar. Los tipos posibles son **event** y **message**. Por defecto, se retornan todas las notificaciones. No distingue mayúsculas de minúsculas. **Aclaración**: un valor incorrecto producirá que no se retornen notificaciones.