### PR TITLE
Eliminación de restricción de números en símbolo de unidad de medición

### DIFF
--- a/app/mod_profiles/common/parsers/measurementUnit.py
+++ b/app/mod_profiles/common/parsers/measurementUnit.py
@@ -8,7 +8,7 @@ from app.mod_profiles.validators.generic_validators import is_boolean, string_wi
 # Parser general
 parser = reqparse.RequestParser()
 parser.add_argument('name', type=string_without_int, required=True)
-parser.add_argument('symbol', type=string_without_int, required=True)
+parser.add_argument('symbol', type=str, required=True)
 parser.add_argument('suffix', type=is_boolean)
 
 # Parser para recurso POST


### PR DESCRIPTION
Se permite la inclusión de caracteres numéricos en el campo ```symbol``` de **MeasurementUnit**.