### PR TITLE
Especificación de valores por defecto en constructores, para Flask-Admin

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -207,9 +207,16 @@ def init_login():
 
 # Create customized model view class
 class MyModelView(sqla.ModelView):
-
     def is_accessible(self):
         return login.current_user.is_authenticated
+
+
+# Create customized model view class
+class UserView(MyModelView):
+    can_create = False
+    column_exclude_list = [
+        'rsa_private_key',
+    ]
 
 
 # Create customized index view class that handles login & registration
@@ -266,6 +273,6 @@ admin.add_view(MyModelView(models.MeasurementUnit, db.session))
 admin.add_view(MyModelView(models.PermissionType, db.session))
 admin.add_view(MyModelView(models.StorageLocation, db.session))
 admin.add_view(MyModelView(models.TypeUnitValidation, db.session))
-admin.add_view(MyModelView(models.User, db.session))
+admin.add_view(UserView(models.User, db.session))
 
 from . import views

--- a/app/mod_profiles/models/Gender.py
+++ b/app/mod_profiles/models/Gender.py
@@ -9,7 +9,7 @@ class Gender(db.Model):
     name        = db.Column(db.String(50), unique=True)
     description = db.Column(db.String(255))
 
-    def __init__(self, name, description):
+    def __init__(self, name='', description=''):
         self.name        = name
         self.description = description
 

--- a/app/mod_profiles/models/GroupMembershipType.py
+++ b/app/mod_profiles/models/GroupMembershipType.py
@@ -9,7 +9,7 @@ class GroupMembershipType(db.Model):
     name        = db.Column(db.String(50))
     description = db.Column(db.String(255))
 
-    def __init__(self, name, description):
+    def __init__(self, name='', description=''):
         self.name        = name
         self.description = description
 

--- a/app/mod_profiles/models/MeasurementSource.py
+++ b/app/mod_profiles/models/MeasurementSource.py
@@ -9,7 +9,7 @@ class MeasurementSource(db.Model):
     name        = db.Column(db.String(50), unique=True)
     description = db.Column(db.String(255))
 
-    def __init__(self, name, description):
+    def __init__(self, name='', description=''):
         self.name        = name
         self.description = description
 

--- a/app/mod_profiles/models/MeasurementType.py
+++ b/app/mod_profiles/models/MeasurementType.py
@@ -9,7 +9,7 @@ class MeasurementType(db.Model):
     name        = db.Column(db.String(50), unique=True)
     description = db.Column(db.String(255))
 
-    def __init__(self, name, description):
+    def __init__(self, name='', description=''):
         self.name        = name
         self.description = description
 

--- a/app/mod_profiles/models/MeasurementUnit.py
+++ b/app/mod_profiles/models/MeasurementUnit.py
@@ -10,7 +10,7 @@ class MeasurementUnit(db.Model):
     symbol = db.Column(db.String(10))
     suffix = db.Column(db.Boolean)
 
-    def __init__(self, name, symbol, suffix):
+    def __init__(self, name='', symbol='', suffix=False):
         self.name   = name
         self.symbol = symbol
         self.suffix = suffix

--- a/app/mod_profiles/models/PermissionType.py
+++ b/app/mod_profiles/models/PermissionType.py
@@ -15,9 +15,9 @@ class PermissionType(db.Model):
     can_edit_comments       = db.Column(db.Boolean)
     can_edit_measurements   = db.Column(db.Boolean)
 
-    def __init__(self, name, description, can_view_analysis_files, can_view_comments,
-                 can_view_measurements, can_edit_analysis_files, can_edit_comments,
-                 can_edit_measurements):
+    def __init__(self, name='', description='', can_view_analysis_files=False, can_view_comments=False,
+                 can_view_measurements=False, can_edit_analysis_files=False, can_edit_comments=False,
+                 can_edit_measurements=False):
         self.name                    = name
         self.description             = description
         self.can_view_analysis_files = can_view_analysis_files

--- a/app/mod_profiles/models/StorageLocation.py
+++ b/app/mod_profiles/models/StorageLocation.py
@@ -10,7 +10,7 @@ class StorageLocation(db.Model):
     description = db.Column(db.String(255))
     website     = db.Column(db.String(50))
 
-    def __init__(self, name, description, website):
+    def __init__(self, name='', description='', website=''):
         self.name        = name
         self.description = description
         self.website     = website

--- a/app/mod_profiles/models/TypeUnitValidation.py
+++ b/app/mod_profiles/models/TypeUnitValidation.py
@@ -17,7 +17,7 @@ class TypeUnitValidation(db.Model):
     measurement_unit = db.relationship('MeasurementUnit',
                                        backref=db.backref('validations', lazy='dynamic'))
 
-    def __init__(self, min_value, max_value, type_id, unit_id):
+    def __init__(self, min_value=0, max_value=0, type_id=None, unit_id=None):
         self.min_value           = min_value
         self.max_value           = max_value
         self.measurement_type_id = type_id


### PR DESCRIPTION
Se añaden los **valores por defecto** en los parámetros de los constructores, para soportar correctamente la **creación de nuevos objetos** desde *Flask-Admin*. **[1]**

Además, se quita la opción de **creación de usuarios** desde *Flask-Admin*.

**[1]** https://stackoverflow.com/questions/17254840/unable-to-create-models-on-flask-admin